### PR TITLE
Streamline initial data loading

### DIFF
--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, useContext, useEffect, useState } from "react"
+import { createContext, useContext, useEffect, useState, useCallback, useRef } from "react"
 import PropTypes from "prop-types"
 import { supabase, getCurrentUser, createUserProfile, getUserProfile } from '../lib/supabase'
 
@@ -19,9 +19,55 @@ export function AuthProvider({ children }) {
   const [userProfile, setUserProfile] = useState(null)
   const [loading, setLoading] = useState(true)
   const [initializing, setInitializing] = useState(true)
+  const isMountedRef = useRef(true)
+
+  const setUserProfileSafe = useCallback(
+    (profile) => {
+      if (isMountedRef.current) {
+        setUserProfile(profile)
+      }
+    },
+    [setUserProfile],
+  )
+
+  const loadUserProfile = useCallback(async (userId, sessionUser) => {
+    try {
+      const { data: profile, error } = await getUserProfile(userId)
+
+      if (error && error.code === "PGRST116") {
+        if (!sessionUser) {
+          setUserProfileSafe(null)
+          return
+        }
+
+        const { data: newProfile, error: createError } = await createUserProfile(
+          sessionUser.id,
+          sessionUser.email,
+          sessionUser.user_metadata?.full_name || sessionUser.email,
+        )
+
+        if (createError) {
+          console.error("Error creating user profile:", createError)
+          setUserProfileSafe(null)
+          return
+        }
+
+        setUserProfileSafe(newProfile?.[0] || null)
+      } else if (!error) {
+        setUserProfileSafe(profile)
+      } else {
+        console.error("Error loading user profile:", error)
+        setUserProfileSafe(null)
+      }
+    } catch (error) {
+      console.error("Error loading user profile:", error)
+      // Don't block the app if profile loading fails
+      setUserProfileSafe(null)
+    }
+  }, [setUserProfileSafe])
 
   useEffect(() => {
-    let mounted = true
+    isMountedRef.current = true
 
     // Get initial session with timeout
     const getInitialSession = async () => {
@@ -33,24 +79,32 @@ export function AuthProvider({ children }) {
 
         const { user: currentUser } = await Promise.race([sessionPromise, timeoutPromise])
 
-        if (!mounted) return
+        if (!isMountedRef.current) return
 
         setUser(currentUser)
 
         if (currentUser) {
-          await loadUserProfile(currentUser.id)
+          setLoading(true)
+          loadUserProfile(currentUser.id, currentUser).finally(() => {
+            if (isMountedRef.current) {
+              setLoading(false)
+            }
+          })
+        } else {
+          setUserProfileSafe(null)
+          setLoading(false)
         }
       } catch (error) {
         console.error("Error getting initial session:", error)
         // Don't stay stuck - continue with no user
-        if (mounted) {
+        if (isMountedRef.current) {
           setUser(null)
-          setUserProfile(null)
+          setUserProfileSafe(null)
+          setLoading(false)
         }
       } finally {
-        if (mounted) {
+        if (isMountedRef.current) {
           setInitializing(false)
-          setLoading(false)
         }
       }
     }
@@ -61,7 +115,7 @@ export function AuthProvider({ children }) {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange(async (event, session) => {
-      if (!mounted) return
+      if (!isMountedRef.current) return
 
       console.log("Auth state changed:", event, session?.user?.id)
 
@@ -69,14 +123,28 @@ export function AuthProvider({ children }) {
         setUser(session?.user ?? null)
 
         if (session?.user) {
-          await loadUserProfile(session.user.id)
-        } else {
-          setUserProfile(null)
+          setLoading(true)
+          loadUserProfile(session.user.id, session.user)
+            .catch((error) => {
+              console.error("Error handling auth state change:", error)
+            })
+            .finally(() => {
+              if (isMountedRef.current) {
+                setLoading(false)
+                setInitializing(false)
+              }
+            })
+          return
+        }
+
+        setUserProfileSafe(null)
+        if (isMountedRef.current) {
+          setLoading(false)
+          setInitializing(false)
         }
       } catch (error) {
         console.error("Error handling auth state change:", error)
-      } finally {
-        if (mounted) {
+        if (isMountedRef.current) {
           setLoading(false)
           setInitializing(false)
         }
@@ -85,7 +153,7 @@ export function AuthProvider({ children }) {
 
     // Listen for demo auth changes
     const handleDemoAuthChange = async (event) => {
-      if (!mounted) return
+      if (!isMountedRef.current) return
 
       const { session, event: authEvent } = event.detail
       console.log("Demo auth state changed:", authEvent, session?.user?.id)
@@ -94,14 +162,28 @@ export function AuthProvider({ children }) {
         setUser(session?.user ?? null)
 
         if (session?.user) {
-          await loadUserProfile(session.user.id)
-        } else {
-          setUserProfile(null)
+          setLoading(true)
+          loadUserProfile(session.user.id, session.user)
+            .catch((error) => {
+              console.error("Error handling demo auth state change:", error)
+            })
+            .finally(() => {
+              if (isMountedRef.current) {
+                setLoading(false)
+                setInitializing(false)
+              }
+            })
+          return
+        }
+
+        setUserProfileSafe(null)
+        if (isMountedRef.current) {
+          setLoading(false)
+          setInitializing(false)
         }
       } catch (error) {
         console.error("Error handling demo auth state change:", error)
-      } finally {
-        if (mounted) {
+        if (isMountedRef.current) {
           setLoading(false)
           setInitializing(false)
         }
@@ -111,36 +193,11 @@ export function AuthProvider({ children }) {
     window.addEventListener("demo-auth-change", handleDemoAuthChange)
 
     return () => {
-      mounted = false
+      isMountedRef.current = false
       subscription.unsubscribe()
       window.removeEventListener("demo-auth-change", handleDemoAuthChange)
     }
-  }, [])
-
-  const loadUserProfile = async (userId) => {
-    try {
-      const { data: profile, error } = await getUserProfile(userId)
-
-      if (error && error.code === "PGRST116") {
-        // Profile doesn't exist, create it
-        const user = await getCurrentUser()
-        if (user.user) {
-          const { data: newProfile } = await createUserProfile(
-            user.user.id,
-            user.user.email,
-            user.user.user_metadata?.full_name || user.user.email,
-          )
-          setUserProfile(newProfile?.[0] || null)
-        }
-      } else if (!error) {
-        setUserProfile(profile)
-      }
-    } catch (error) {
-      console.error("Error loading user profile:", error)
-      // Don't block the app if profile loading fails
-      setUserProfile(null)
-    }
-  }
+  }, [loadUserProfile, setUserProfileSafe])
 
   const value = {
     user,


### PR DESCRIPTION
## Summary
- avoid blocking the auth provider on profile fetches and reuse the active session when creating profiles
- parallelize budget and category loading to reduce post-login wait times while resetting defaults on sign-out
- guard profile state updates so they only run when the provider is still mounted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ef305a1c832eb2c71834045ab546