### PR TITLE
Add budget cycle selection and Supabase support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,8 @@ function AppContent() {
             name: budget.name,
             createdAt: new Date(budget.created_at).toLocaleDateString(),
             categoryBudgets: budget.category_budgets || [],
+            cycleType: budget.cycle_type || "monthly",
+            cycleSettings: budget.cycle_settings ?? null,
             transactions:
               budget.transactions?.map((tx) => ({
                 id: tx.id,

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -1,25 +1,101 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { createBudget, updateBudget, deleteBudget } from "../lib/supabase"
+import { useAuth } from "../contexts/AuthContext"
 
 export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode, setBudgets, userId }) {
+  const { userProfile } = useAuth()
   const [editingBudgetId, setEditingBudgetId] = useState(null)
   const [budgetNameInput, setBudgetNameInput] = useState("")
   const [openMenuId, setOpenMenuId] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
+  const [selectedCycleType, setSelectedCycleType] = useState("monthly")
+  const [payFrequencyDays, setPayFrequencyDays] = useState(14)
+  const [customDurationDays, setCustomDurationDays] = useState(30)
+
+  const planTierRaw = userProfile?.planTier ?? userProfile?.plan ?? "Free"
+  const normalizedPlanTier = useMemo(() => {
+    if (typeof planTierRaw === "string") {
+      return planTierRaw.toLowerCase()
+    }
+    return String(planTierRaw || "free").toLowerCase()
+  }, [planTierRaw])
+  const isFreePlan = normalizedPlanTier === "free"
+
+  const cycleOptions = [
+    {
+      value: "monthly",
+      label: "Monthly",
+      description: "Reset your budget every calendar month.",
+      gated: false,
+    },
+    {
+      value: "per_paycheck",
+      label: "Per-paycheck",
+      description: "Sync your budget cadence with each paycheck.",
+      gated: true,
+    },
+    {
+      value: "custom",
+      label: "Custom",
+      description: "Choose a custom period that works for you.",
+      gated: true,
+    },
+  ]
+
+  const cycleLabels = {
+    monthly: "Monthly",
+    per_paycheck: "Per-paycheck",
+    custom: "Custom",
+  }
+
+  const isCycleTypeGated = (cycleType) => ["per_paycheck", "custom"].includes(cycleType)
 
   const openBudget = (budget) => {
     setSelectedBudget(budget)
     setViewMode("details")
   }
 
-  const createNewBudget = async () => {
+  const createNewBudget = () => {
+    setSelectedCycleType("monthly")
+    setPayFrequencyDays(14)
+    setCustomDurationDays(30)
+    setShowCreateDialog(true)
+  }
+
+  const closeCreateDialog = () => {
+    if (!loading) {
+      setShowCreateDialog(false)
+    }
+  }
+
+  const handleConfirmCreateBudget = async () => {
+    if (isFreePlan && ["per_paycheck", "custom"].includes(selectedCycleType)) {
+      return
+    }
+
     setLoading(true)
     try {
+      let cycleSettings = null
+      if (selectedCycleType === "per_paycheck") {
+        const frequency = Number.parseInt(payFrequencyDays, 10)
+        cycleSettings = {
+          payFrequencyDays: Number.isNaN(frequency) || frequency < 1 ? 14 : frequency,
+        }
+      } else if (selectedCycleType === "custom") {
+        const duration = Number.parseInt(customDurationDays, 10)
+        cycleSettings = {
+          durationDays: Number.isNaN(duration) || duration < 1 ? 30 : duration,
+        }
+      }
+
       const newBudgetData = {
         name: `My Budget`,
         categoryBudgets: [],
+        cycleType: selectedCycleType,
+        cycleSettings,
       }
 
       const { data, error } = await createBudget(userId, newBudgetData)
@@ -32,9 +108,12 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
           name: data[0].name,
           createdAt: new Date(data[0].created_at).toLocaleDateString(),
           categoryBudgets: data[0].category_budgets || [],
+          cycleType: data[0].cycle_type || selectedCycleType,
+          cycleSettings: data[0].cycle_settings ?? cycleSettings,
           transactions: [],
         }
         setBudgets([newBudget, ...budgets])
+        setShowCreateDialog(false)
       }
     } catch (error) {
       console.error("Error creating budget:", error)
@@ -79,6 +158,8 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
       const duplicateData = {
         name: `${budget.name} (Copy)`,
         categoryBudgets: budget.categoryBudgets || [],
+        cycleType: budget.cycleType || "monthly",
+        cycleSettings: budget.cycleSettings ?? null,
       }
 
       const { data, error } = await createBudget(userId, duplicateData)
@@ -91,6 +172,8 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
           name: data[0].name,
           createdAt: new Date(data[0].created_at).toLocaleDateString(),
           categoryBudgets: data[0].category_budgets || [],
+          cycleType: data[0].cycle_type || duplicateData.cycleType,
+          cycleSettings: data[0].cycle_settings ?? duplicateData.cycleSettings,
           transactions: [],
         }
         setBudgets([newBudget, ...budgets])
@@ -133,7 +216,7 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
         <div className="empty-state">
           <p>Welcome to Pocket Budget! Create your first budget to get started.</p>
           <button className="primary-button" onClick={createNewBudget} disabled={loading}>
-            {loading ? "Creating..." : "Create Your First Budget"}
+            {loading ? "Please wait..." : "Create Your First Budget"}
           </button>
         </div>
       ) : (
@@ -161,42 +244,58 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
           })
 
           const isAnyCategoryOver = categorySummaries.some((cat) => cat.isOver)
+          const cycleType = budget.cycleType || "monthly"
+          const cycleLabel = cycleLabels[cycleType] || cycleLabels.monthly
+          const cycleIsGated = isCycleTypeGated(cycleType)
 
           return (
             <div key={budget.id} className="budgetCard">
               <div className="budgetCard-content">
                 <div className="budgetCard-info" onClick={() => openBudget(budget)}>
-                  {editingBudgetId === budget.id ? (
-                    <input
-                      className="input budget-name-input"
-                      value={budgetNameInput}
-                      onChange={(e) => setBudgetNameInput(e.target.value)}
-                      onBlur={() => saveBudgetName(budget)}
-                      onKeyPress={(e) => {
-                        if (e.key === "Enter") {
-                          saveBudgetName(budget)
-                        }
-                      }}
-                      autoFocus
-                      disabled={loading}
-                    />
-                  ) : (
-                    <div
-                      className="budgetName"
-                      onClick={(e) => {
-                        e.stopPropagation()
-                        setEditingBudgetId(budget.id)
-                        setBudgetNameInput(budget.name)
-                      }}
-                    >
-                      {budget.name}
-                      {isAnyCategoryOver && (
-                        <span className="expense" style={{ marginLeft: "0.5rem" }}>
-                          🚩
-                        </span>
+                  <div className="budgetCard-headerRow">
+                    <div className="budgetNameWrapper">
+                      {editingBudgetId === budget.id ? (
+                        <input
+                          className="input budget-name-input"
+                          value={budgetNameInput}
+                          onChange={(e) => setBudgetNameInput(e.target.value)}
+                          onBlur={() => saveBudgetName(budget)}
+                          onClick={(e) => e.stopPropagation()}
+                          onKeyPress={(e) => {
+                            if (e.key === "Enter") {
+                              saveBudgetName(budget)
+                            }
+                          }}
+                          autoFocus
+                          disabled={loading}
+                        />
+                      ) : (
+                        <div
+                          className="budgetName"
+                          onClick={(e) => {
+                            e.stopPropagation()
+                            setEditingBudgetId(budget.id)
+                            setBudgetNameInput(budget.name)
+                          }}
+                        >
+                          {budget.name}
+                          {isAnyCategoryOver && (
+                            <span className="expense" style={{ marginLeft: "0.5rem" }}>
+                              🚩
+                            </span>
+                          )}
+                        </div>
                       )}
                     </div>
-                  )}
+                    <div
+                      className={`budgetCycleLabel ${cycleIsGated ? "locked" : ""}`}
+                      onClick={(e) => e.stopPropagation()}
+                      title={`${cycleLabel} cycle${cycleIsGated ? " (Premium)" : ""}`}
+                    >
+                      {cycleIsGated && <span className="cycleLockIcon">🔒</span>}
+                      <span>{cycleLabel}</span>
+                    </div>
+                  </div>
 
                   <div className="budgetBalance">
                     Balance: <span className={balance >= 0 ? "income" : "expense"}>${balance.toFixed(2)}</span>
@@ -286,11 +385,115 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
       {budgets.length > 0 && (
         <div className="budget-actions">
           <button className="addButton primary-button" onClick={createNewBudget} disabled={loading}>
-            {loading ? "Creating..." : "Create New Budget"}
+            {loading ? "Please wait..." : "Create New Budget"}
           </button>
           <button className="cancelButton secondary-button cate-btn" onClick={() => setViewMode("categories")}>
             Manage Categories
           </button>
+        </div>
+      )}
+
+      {showCreateDialog && (
+        <div className="modalBackdrop">
+          <div className="modalContent enhanced-modal createBudgetModal">
+            <h2 className="header modal-header">Choose a budget cycle</h2>
+            <p className="modal-subtitle">Pick how often this budget should reset.</p>
+
+            <div className="cycleOptions">
+              {cycleOptions.map((option) => {
+                const isLocked = option.gated && isFreePlan
+                const isSelected = selectedCycleType === option.value
+                const optionClassNames = [
+                  "cycleOption",
+                  isSelected && !isLocked ? "selected" : "",
+                  isLocked ? "locked" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")
+
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={optionClassNames}
+                    onClick={() => {
+                      if (isLocked) return
+                      setSelectedCycleType(option.value)
+                    }}
+                    disabled={isLocked}
+                  >
+                    <div className="cycleOption-text">
+                      <div className="cycleOption-label">
+                        {isLocked && <span className="cycleLockIcon">🔒</span>}
+                        {option.label}
+                      </div>
+                      <div className="cycleOption-description">{option.description}</div>
+                    </div>
+                    {isSelected && !isLocked && <span className="cycleOption-selected">✓</span>}
+                  </button>
+                )
+              })}
+            </div>
+
+            {selectedCycleType === "per_paycheck" && !isFreePlan && (
+              <div className="cycleSettingsRow">
+                <label className="cycleSettingsLabel" htmlFor="payFrequencyDays">
+                  Pay frequency (days)
+                </label>
+                <input
+                  id="payFrequencyDays"
+                  type="number"
+                  min="1"
+                  className="input"
+                  value={payFrequencyDays}
+                  onChange={(e) => setPayFrequencyDays(e.target.value)}
+                />
+              </div>
+            )}
+
+            {selectedCycleType === "custom" && !isFreePlan && (
+              <div className="cycleSettingsRow">
+                <label className="cycleSettingsLabel" htmlFor="customDurationDays">
+                  Custom cycle length (days)
+                </label>
+                <input
+                  id="customDurationDays"
+                  type="number"
+                  min="1"
+                  className="input"
+                  value={customDurationDays}
+                  onChange={(e) => setCustomDurationDays(e.target.value)}
+                />
+              </div>
+            )}
+
+            {isFreePlan && (
+              <div className="upgradeCta">
+                <p>Upgrade to unlock Per-paycheck and Custom budget cycles.</p>
+                <a
+                  className="upgradeCta-link"
+                  href="https://pocketbudget.app/upgrade"
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Upgrade your plan
+                </a>
+              </div>
+            )}
+
+            <div className="modal-actions">
+              <button
+                className="addButton primary-button"
+                onClick={handleConfirmCreateBudget}
+                disabled={loading || (isFreePlan && isCycleTypeGated(selectedCycleType))}
+              >
+                {loading ? "Creating..." : "Create Budget"}
+              </button>
+              <button className="cancelButton secondary-button" onClick={closeCreateDialog} disabled={loading}>
+                Cancel
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1613,6 +1613,12 @@ body {
   animation: slideUp 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
+.modal-subtitle {
+  margin: 0.35rem 0 0;
+  color: var(--gray-600);
+  font-size: 0.95rem;
+}
+
 @keyframes slideUp {
   from {
     opacity: 0;
@@ -1634,6 +1640,149 @@ body {
 .modal-actions .cancelButton {
   flex: 1;
   margin: 0;
+}
+
+.budgetCard-headerRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.budgetNameWrapper {
+  flex: 1;
+  min-width: 0;
+}
+
+.budgetCycleLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gray-700);
+  background: var(--gray-100);
+  border-radius: var(--radius-full);
+  padding: 0.25rem 0.75rem;
+  border: 1px solid var(--gray-200);
+  white-space: nowrap;
+}
+
+.budgetCycleLabel.locked {
+  color: var(--purple-700);
+  background: rgba(109, 40, 217, 0.12);
+  border-color: rgba(109, 40, 217, 0.25);
+}
+
+.cycleLockIcon {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.createBudgetModal {
+  max-width: 420px;
+}
+
+.cycleOptions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.cycleOption {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--gray-200);
+  background: var(--gray-50);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-align: left;
+  width: 100%;
+  gap: 0.75rem;
+}
+
+.cycleOption:hover:not(.locked) {
+  border-color: var(--primary-500);
+  box-shadow: var(--shadow-sm);
+  background: white;
+}
+
+.cycleOption.selected {
+  border-color: var(--primary-600);
+  background: white;
+  box-shadow: var(--shadow-md);
+}
+
+.cycleOption.locked {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.cycleOption-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cycleOption-label {
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--gray-900);
+}
+
+.cycleOption-description {
+  font-size: 0.85rem;
+  color: var(--gray-600);
+}
+
+.cycleOption-selected {
+  font-weight: 700;
+  color: var(--primary-600);
+  font-size: 1.1rem;
+}
+
+.cycleSettingsRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.cycleSettingsLabel {
+  font-weight: 600;
+  color: var(--gray-700);
+  font-size: 0.9rem;
+}
+
+.upgradeCta {
+  margin-top: 1rem;
+  padding: 0.75rem 1rem;
+  background: rgba(109, 40, 217, 0.08);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(109, 40, 217, 0.2);
+  text-align: center;
+  color: var(--purple-700);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.upgradeCta-link {
+  color: var(--primary-600);
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.upgradeCta-link:hover {
+  text-decoration: underline;
 }
 /* Chart styles */
 .chartContainer {


### PR DESCRIPTION
## Summary
- extend the Supabase budget helpers to persist cycle type metadata
- surface cycle information in the app state and budget cards
- add a gated creation dialog so users can pick a cycle and see upgrade prompts for paid cadences

## Testing
- npm run build *(fails: vite CLI is not available in the repository-provided node_modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b16a20c4832e86bf2f6b88dc17cb