### PR TITLE
Add goals screen with upgrade messaging

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,49 @@
-export default function Footer() {
-    return (
-        <div className="fds-footer">
-            <p className="tagline">🏆 Greatness Magnified - Made with ❤️</p>
-        </div>
-    )
+export default function Footer({ activeView, onNavigate, onExitGoals, isPaidUser, planName }) {
+  const handleBudgetsClick = () => {
+    if (activeView === "goals" && typeof onExitGoals === "function") {
+      onExitGoals()
+      return
+    }
+
+    onNavigate?.("budgets")
+  }
+
+  return (
+    <footer className="app-footer">
+      <div className="footer-nav" role="tablist" aria-label="Quick navigation">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeView === "budgets"}
+          className={`footer-tab ${activeView === "budgets" ? "footer-tab-active" : ""}`}
+          onClick={handleBudgetsClick}
+        >
+          Budgets
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeView === "categories"}
+          className={`footer-tab ${activeView === "categories" ? "footer-tab-active" : ""}`}
+          onClick={() => onNavigate?.("categories")}
+        >
+          Categories
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={activeView === "goals"}
+          className={`footer-tab ${activeView === "goals" ? "footer-tab-active" : ""}`}
+          onClick={() => onNavigate?.("goals")}
+        >
+          Goals
+          {!isPaidUser && <span className="footer-tab-pill">Pro</span>}
+        </button>
+      </div>
+      <p className="tagline">
+        🏆 Greatness Magnified - Made with ❤️
+        {!isPaidUser && planName && <span className="tagline-plan"> • Current plan: {planName}</span>}
+      </p>
+    </footer>
+  )
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,23 @@
 import { signOut } from "../lib/supabase-mock"
 import { useAuth } from "../contexts/AuthContext"
 
-export default function Header({ title, showLogout = false }) {
+const VIEW_LABELS = {
+  budgets: "Budgets",
+  categories: "Categories",
+  details: "Budget",
+  ai: "AI Report",
+  goals: "Goals",
+}
+
+export default function Header({
+  title,
+  showLogout = false,
+  activeView,
+  onNavigate,
+  onExitGoals,
+  isPaidUser,
+  planName,
+}) {
   const { user, userProfile } = useAuth()
 
   const handleSignOut = async () => {
@@ -10,10 +26,30 @@ export default function Header({ title, showLogout = false }) {
     }
   }
 
+  const handleNavigate = (target) => {
+    if (!onNavigate) return
+
+    if (activeView === "goals" && target === "budgets" && typeof onExitGoals === "function") {
+      onExitGoals()
+      return
+    }
+
+    onNavigate(target)
+  }
+
+  const planBadge = !isPaidUser ? "Pro" : null
+
   return (
     <div className="app-header">
       <div className="header-content">
-        <h1 className="header-title">{title}</h1>
+        <div>
+          <h1 className="header-title">{title}</h1>
+          {planBadge && (
+            <div className="header-plan-pill" aria-live="polite">
+              Goals are a {planBadge} feature • Current plan: {planName || "Free"}
+            </div>
+          )}
+        </div>
         {showLogout && user && (
           <div className="header-user">
             <span className="user-email">{userProfile?.full_name || user.email}</span>
@@ -23,6 +59,30 @@ export default function Header({ title, showLogout = false }) {
           </div>
         )}
       </div>
+      {onNavigate && (
+        <div className="header-tabs" role="tablist" aria-label="Main navigation">
+          {[
+            { id: "budgets", label: "Budgets" },
+            { id: "categories", label: "Categories" },
+            { id: "goals", label: "Goals" },
+          ].map((tab) => (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={activeView === tab.id}
+              className={`header-tab ${activeView === tab.id ? "header-tab-active" : ""}`}
+              onClick={() => handleNavigate(tab.id)}
+            >
+              {tab.label}
+              {tab.id === "goals" && !isPaidUser && <span className="header-tab-pill">Pro</span>}
+            </button>
+          ))}
+          {activeView === "details" && (
+            <span className="header-tab breadcrumb-pill">{VIEW_LABELS[activeView]}</span>
+          )}
+          {activeView === "ai" && <span className="header-tab breadcrumb-pill">{VIEW_LABELS[activeView]}</span>}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/screens/GoalsScreen.jsx
+++ b/src/screens/GoalsScreen.jsx
@@ -1,0 +1,150 @@
+"use client"
+
+import { useMemo } from "react"
+import { useAuth } from "../contexts/AuthContext"
+
+const VIEW_LABELS = {
+  budgets: "Budgets",
+  details: "Budget Details",
+  categories: "Categories",
+  ai: "AI Insights",
+}
+
+const formatCurrency = (value) => {
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+const formatDate = (value) => {
+  if (!value) return "No target date"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return value
+  }
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+}
+
+export default function GoalsScreen({ goals, isPaidUser, onCreateGoal, onExit, previousViewMode, planName }) {
+  const { userProfile } = useAuth()
+
+  const displayGoals = useMemo(() => {
+    if (goals?.length) {
+      return goals
+    }
+
+    return [
+      {
+        id: "sample-goal-1",
+        name: "Dream Vacation",
+        targetAmount: 3500,
+        savedAmount: 1500,
+        dueDate: "2025-08-20",
+        milestones: [
+          { id: "sample-goal-1-m1", name: "Pick the destination", amount: 0, completed: true },
+          { id: "sample-goal-1-m2", name: "Book flights", amount: 1200, completed: false },
+          { id: "sample-goal-1-m3", name: "Reserve lodging", amount: 2500, completed: false },
+          { id: "sample-goal-1-m4", name: "Start itinerary", amount: 3500, completed: false },
+        ],
+      },
+    ]
+  }, [goals])
+
+  const previousViewLabel = VIEW_LABELS[previousViewMode] || "Budgets"
+  const planDisplay = planName || userProfile?.planTier || "Free"
+
+  return (
+    <div className="goals-screen">
+      <div className="header-nav">
+        <button className="cancelButton secondary-button" onClick={onExit}>
+          ← Back to {previousViewLabel}
+        </button>
+        <button className="primary-button" onClick={onCreateGoal} disabled={!isPaidUser}>
+          {isPaidUser ? "Create a Goal" : "Upgrade to Create Goals"}
+        </button>
+      </div>
+
+      {!isPaidUser && (
+        <div className="goal-upgrade-banner">
+          <div className="goal-upgrade-content">
+            <h2>Unlock Goal Tracking with Pocket Budget Pro</h2>
+            <p>
+              You're currently on the <strong>{planDisplay}</strong> plan. Upgrade to create custom goals, automate
+              milestone reminders, and connect savings accounts.
+            </p>
+            <ul className="goal-upgrade-list">
+              <li>Set unlimited savings goals tailored to your priorities</li>
+              <li>Track milestone progress with celebratory insights</li>
+              <li>Stay motivated with auto reminders and smart nudges</li>
+            </ul>
+            <button className="secondary-button goal-upgrade-button" disabled>
+              Coming Soon: Upgrade Flow
+            </button>
+          </div>
+        </div>
+      )}
+
+      <div className={`goals-grid ${!isPaidUser ? "goals-grid-locked" : ""}`}>
+        {displayGoals.map((goal) => {
+          const progress = goal.targetAmount
+            ? Math.min(100, Math.round((goal.savedAmount / goal.targetAmount) * 100))
+            : 0
+
+          return (
+            <div key={goal.id} className={`goal-card ${!isPaidUser ? "goal-card-locked" : ""}`}>
+              {!isPaidUser && (
+                <div className="goal-card-overlay">
+                  <span>Upgrade to Pocket Budget Pro to update goal progress</span>
+                </div>
+              )}
+
+              <div className="goal-card-header">
+                <div>
+                  <h3 className="goal-title">{goal.name}</h3>
+                  <p className="goal-date">Target date: {formatDate(goal.dueDate)}</p>
+                </div>
+                <div className="goal-progress-stats">
+                  <span className="goal-amount">{formatCurrency(goal.savedAmount)}</span>
+                  <span className="goal-target">of {formatCurrency(goal.targetAmount)}</span>
+                </div>
+              </div>
+
+              <div className="goal-progress-bar">
+                <div className="goal-progress-bar-fill" style={{ width: `${progress}%` }} />
+              </div>
+              <div className="goal-progress-meta">{progress}% complete</div>
+
+              <div className="milestones-heading">Milestones</div>
+              <div className="milestones-grid">
+                {goal.milestones?.map((milestone) => (
+                  <div
+                    key={milestone.id}
+                    className={`milestone-card ${milestone.completed ? "milestone-completed" : ""} ${
+                      !isPaidUser ? "milestone-locked" : ""
+                    }`}
+                  >
+                    <div className="milestone-status" aria-hidden>
+                      {milestone.completed ? "✅" : "🟡"}
+                    </div>
+                    <div className="milestone-content">
+                      <div className="milestone-title">{milestone.name}</div>
+                      {milestone.amount > 0 && (
+                        <div className="milestone-amount">{formatCurrency(milestone.amount)}</div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1099,6 +1099,303 @@ body {
   flex-wrap: wrap;
 }
 
+/* Header navigation */
+.header-tabs {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.header-tab {
+  position: relative;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-full);
+  border: 1px solid var(--gray-200);
+  background: white;
+  color: var(--gray-600);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.header-tab:hover {
+  color: var(--primary-600);
+  border-color: var(--primary-300);
+  box-shadow: var(--shadow-sm);
+}
+
+.header-tab-active {
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-500));
+  color: white;
+  border-color: transparent;
+  box-shadow: var(--shadow-md);
+}
+
+.header-tab-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--purple-100);
+  color: var(--purple-700);
+  border-radius: var(--radius-full);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.15rem 0.5rem;
+  margin-left: 0.5rem;
+}
+
+.breadcrumb-pill {
+  background: var(--gray-100);
+  color: var(--gray-600);
+  border-radius: var(--radius-full);
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+}
+
+.header-plan-pill {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+/* Footer navigation */
+.app-footer {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--gray-200);
+}
+
+.footer-nav {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.footer-tab {
+  position: relative;
+  border: 1px solid var(--gray-200);
+  background: white;
+  color: var(--gray-600);
+  border-radius: var(--radius-full);
+  padding: 0.5rem 1.25rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.footer-tab:hover {
+  border-color: var(--primary-300);
+  color: var(--primary-600);
+}
+
+.footer-tab-active {
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-500));
+  color: white;
+  border-color: transparent;
+  box-shadow: var(--shadow-sm);
+}
+
+.footer-tab-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--purple-100);
+  color: var(--purple-700);
+  border-radius: var(--radius-full);
+  font-size: 0.65rem;
+  font-weight: 700;
+  padding: 0.1rem 0.45rem;
+  margin-left: 0.4rem;
+}
+
+.tagline-plan {
+  font-weight: 500;
+  color: var(--gray-600);
+}
+
+/* Goals screen */
+.goals-screen {
+  margin-top: 1.5rem;
+}
+
+.goal-upgrade-banner {
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(168, 85, 247, 0.1));
+  border: 1px dashed var(--primary-300);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.goal-upgrade-content h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: var(--gray-900);
+}
+
+.goal-upgrade-content p {
+  color: var(--gray-700);
+  margin-bottom: 1rem;
+}
+
+.goal-upgrade-list {
+  margin: 0 0 1.25rem 1.25rem;
+  color: var(--gray-700);
+  list-style-type: disc;
+  line-height: 1.6;
+}
+
+.goal-upgrade-button {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.goals-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.goals-grid-locked {
+  pointer-events: none;
+}
+
+.goal-card {
+  position: relative;
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.goal-card-locked {
+  opacity: 0.85;
+}
+
+.goal-card-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--gray-600);
+  font-weight: 600;
+  pointer-events: none;
+}
+
+.goal-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.goal-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.goal-date {
+  font-size: 0.875rem;
+  color: var(--gray-500);
+}
+
+.goal-progress-stats {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.goal-amount {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.goal-target {
+  font-size: 0.85rem;
+  color: var(--gray-500);
+}
+
+.goal-progress-bar {
+  height: 0.6rem;
+  background: var(--gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  margin-bottom: 0.75rem;
+}
+
+.goal-progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(135deg, var(--green-400), var(--green-600));
+  transition: width 0.3s ease;
+}
+
+.goal-progress-meta {
+  font-size: 0.85rem;
+  color: var(--gray-500);
+  margin-bottom: 1rem;
+}
+
+.milestones-heading {
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+  color: var(--gray-700);
+}
+
+.milestones-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.milestone-card {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: 0.75rem;
+  background: var(--gray-50);
+}
+
+.milestone-completed {
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.08);
+}
+
+.milestone-locked {
+  opacity: 0.8;
+}
+
+.milestone-status {
+  font-size: 1.5rem;
+}
+
+.milestone-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.milestone-title {
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.milestone-amount {
+  font-size: 0.85rem;
+  color: var(--gray-600);
+}
+
 .pagination-button {
   padding: 0.5rem 0.75rem;
   border: 1px solid var(--gray-300);


### PR DESCRIPTION
## Summary
- add a dedicated Goals screen that previews goals, milestone cards, and upgrade messaging for free users
- extend App state plus navigation so users can enter/exit the Goals view without losing their previous context
- refresh header and footer tabs with plan-aware CTAs and paid gating for goal creation

## Testing
- npm run build *(fails: vite binary missing in container PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b2883334832ebc67af1b99c303ce