### PR TITLE
Add savings goals management and syncing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import BudgetsScreen from "./screens/BudgetsScreen"
 import BudgetDetailsScreen from "./screens/BudgetDetailsScreen"
 import CategoriesScreen from "./screens/CategoriesScreen"
 import AIInsightsScreen from "./screens/AIInsightsScreen"
+import GoalsScreen from "./screens/GoalsScreen"
 import LoginScreen from "./screens/LoginScreen"
 import LoadingScreen from "./components/LoadingScreen"
 import Header from "./components/Header"
@@ -127,7 +128,7 @@ function AppContent() {
 
   return (
     <div className="container">
-      <Header title="Pocket Budget" showLogout={viewMode === "budgets"} />
+      <Header title="Pocket Budget" showLogout={viewMode !== "ai"} />
       <InstallPrompt />
 
       {viewMode === "budgets" && (
@@ -138,6 +139,9 @@ function AppContent() {
           setBudgets={setBudgets}
           userId={user.id}
         />
+      )}
+      {viewMode === "goals" && (
+        <GoalsScreen setViewMode={setViewMode} budgets={budgets} setBudgets={setBudgets} />
       )}
       {viewMode === "details" && selectedBudget && (
         <BudgetDetailsScreen

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -127,6 +127,9 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
     <div>
       <div className="header-section">
         <p className="tagline">Manage your budgets and stay on top of your finances.</p>
+        <div className="header-actions">
+          <button className="secondary-button" onClick={() => setViewMode("goals")}>View savings goals</button>
+        </div>
       </div>
 
       {budgets.length === 0 ? (

--- a/src/screens/GoalsScreen.jsx
+++ b/src/screens/GoalsScreen.jsx
@@ -1,0 +1,689 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  addGoalContribution,
+  createGoal,
+  createTransaction,
+  deleteGoal,
+  getGoals,
+  updateGoal,
+} from "../lib/supabase"
+import { useAuth } from "../contexts/AuthContext"
+
+const DEFAULT_MILESTONES = [25, 50, 75, 100]
+const MS_IN_DAY = 1000 * 60 * 60 * 24
+const MS_IN_WEEK = MS_IN_DAY * 7
+
+const formatCurrency = (value) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(Number(value || 0))
+
+const normalizeContribution = (contribution) => ({
+  ...contribution,
+  amount: Number(contribution.amount || 0),
+  contributed_at: contribution.contributed_at || contribution.date || contribution.created_at || new Date().toISOString(),
+})
+
+const normalizeGoalRecord = (goal) => {
+  const contributions = (goal.goal_contributions || goal.contributions || []).map(normalizeContribution)
+
+  contributions.sort((a, b) => new Date(b.contributed_at) - new Date(a.contributed_at))
+
+  return {
+    ...goal,
+    targetAmount: Number(goal.target_amount ?? goal.targetAmount ?? 0),
+    targetDate: goal.target_date || goal.targetDate || null,
+    status: goal.status || "active",
+    milestones: Array.isArray(goal.milestones) && goal.milestones.length ? goal.milestones : DEFAULT_MILESTONES,
+    linked_budget_id: goal.linked_budget_id || goal.linkedBudgetId || null,
+    goal_contributions: contributions,
+  }
+}
+
+const getStartDate = (goal) => {
+  const created = goal.created_at || goal.createdAt
+  const explicit = goal.start_date || goal.startDate
+  const date = explicit || created
+  const parsed = date ? new Date(date) : new Date()
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed
+}
+
+const getTargetDate = (goal) => {
+  if (!goal.targetDate) return null
+  const parsed = new Date(goal.targetDate)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const getWeekStart = (date) => {
+  const d = new Date(date)
+  const day = d.getDay()
+  const diff = d.getDate() - day + (day === 0 ? -6 : 1) // Monday as first day of week
+  const start = new Date(d.setDate(diff))
+  start.setHours(0, 0, 0, 0)
+  return start
+}
+
+const getGoalMetrics = (goal) => {
+  const now = new Date()
+  const contributions = goal.goal_contributions || []
+  const totalContributed = contributions.reduce((sum, item) => sum + Number(item.amount || 0), 0)
+  const targetAmount = Number(goal.targetAmount || 0)
+  const progress = targetAmount > 0 ? Math.min(100, (totalContributed / targetAmount) * 100) : 0
+  const startDate = getStartDate(goal)
+  const targetDate = getTargetDate(goal)
+
+  let totalDurationMs = targetDate ? targetDate.getTime() - startDate.getTime() : null
+  if (totalDurationMs !== null && totalDurationMs <= 0) {
+    totalDurationMs = MS_IN_WEEK
+  }
+
+  const elapsedMs = Math.max(0, now.getTime() - startDate.getTime())
+  const plannedFraction =
+    totalDurationMs && totalDurationMs > 0 ? Math.min(1, Math.max(0, elapsedMs / totalDurationMs)) : 1
+  const plannedTotal = targetAmount * plannedFraction
+
+  const totalWeeks = totalDurationMs ? Math.max(1, Math.ceil(totalDurationMs / MS_IN_WEEK)) : 1
+  const weeklyTarget = totalWeeks > 0 ? targetAmount / totalWeeks : targetAmount
+
+  const weekStart = getWeekStart(now)
+  const weekEnd = new Date(weekStart.getTime() + MS_IN_WEEK)
+  const contributedThisWeek = contributions
+    .filter((item) => {
+      const contributedDate = new Date(item.contributed_at)
+      return contributedDate >= weekStart && contributedDate < weekEnd
+    })
+    .reduce((sum, item) => sum + Number(item.amount || 0), 0)
+
+  const tolerance = targetAmount * 0.02
+  const delta = totalContributed - plannedTotal
+  let pace = "on-track"
+  if (delta > tolerance) {
+    pace = "ahead"
+  } else if (delta < -tolerance) {
+    pace = "behind"
+  }
+
+  const guidanceShortfall = Math.max(0, weeklyTarget - contributedThisWeek)
+
+  return {
+    totalContributed,
+    progress,
+    weeklyTarget,
+    contributedThisWeek,
+    guidanceShortfall,
+    pace,
+    plannedTotal,
+    totalWeeks,
+  }
+}
+
+export default function GoalsScreen({ setViewMode, budgets = [], setBudgets }) {
+  const { user } = useAuth()
+  const [goals, setGoals] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [creating, setCreating] = useState(false)
+  const [goalForm, setGoalForm] = useState({
+    name: "",
+    targetAmount: "",
+    targetDate: "",
+    linkedBudgetId: "",
+  })
+  const [keypadOpen, setKeypadOpen] = useState(false)
+  const [selectedGoalId, setSelectedGoalId] = useState("")
+  const [keypadValue, setKeypadValue] = useState("")
+  const [contributionNote, setContributionNote] = useState("")
+  const [confettiGoalId, setConfettiGoalId] = useState(null)
+  const [milestoneCelebration, setMilestoneCelebration] = useState(null)
+  const prevProgressRef = useRef({})
+  const [saving, setSaving] = useState(false)
+  const [loggingContribution, setLoggingContribution] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    loadGoals()
+  }, [user])
+
+  const loadGoals = async () => {
+    if (!user) return
+    setLoading(true)
+    setError(null)
+    try {
+      const { data, error: goalsError } = await getGoals(user.id)
+      if (goalsError) {
+        console.error("Error loading goals:", goalsError)
+        setError(goalsError.message || "Failed to load goals")
+        return
+      }
+
+      const normalized = (data || []).map((goal) => normalizeGoalRecord(goal))
+      setGoals(normalized)
+      const progressMap = {}
+      normalized.forEach((goal) => {
+        progressMap[goal.id] = getGoalMetrics(goal).progress
+      })
+      prevProgressRef.current = progressMap
+      if (normalized.length && !selectedGoalId) {
+        setSelectedGoalId(normalized[0].id)
+      }
+    } catch (loadError) {
+      console.error("Unexpected error loading goals:", loadError)
+      setError(loadError.message || "Unexpected error loading goals")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCreateGoal = async (event) => {
+    event.preventDefault()
+    if (!user) return
+
+    const targetAmount = parseFloat(goalForm.targetAmount)
+    if (!goalForm.name.trim() || Number.isNaN(targetAmount) || targetAmount <= 0) {
+      alert("Please provide a goal name and a positive target amount.")
+      return
+    }
+
+    setSaving(true)
+    try {
+      const { data, error: createError } = await createGoal(user.id, {
+        name: goalForm.name.trim(),
+        targetAmount,
+        targetDate: goalForm.targetDate ? new Date(goalForm.targetDate).toISOString() : null,
+        milestones: DEFAULT_MILESTONES,
+        status: "active",
+        linkedBudgetId: goalForm.linkedBudgetId || null,
+      })
+
+      if (createError) {
+        console.error("Error creating goal:", createError)
+        alert(createError.message || "Failed to create goal")
+        return
+      }
+
+      const createdGoal = data?.[0]
+      if (createdGoal) {
+        const normalizedGoal = normalizeGoalRecord(createdGoal)
+        setGoals((prev) => [normalizedGoal, ...prev])
+        prevProgressRef.current[normalizedGoal.id] = getGoalMetrics(normalizedGoal).progress
+        setSelectedGoalId(normalizedGoal.id)
+      }
+
+      setGoalForm({ name: "", targetAmount: "", targetDate: "", linkedBudgetId: "" })
+      setCreating(false)
+    } catch (createUnexpected) {
+      console.error("Unexpected error creating goal:", createUnexpected)
+      alert("Unexpected error creating goal. Please try again.")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDeleteGoal = async (goalId) => {
+    if (!confirm("Delete this goal? Contributions will remain recorded.")) {
+      return
+    }
+    try {
+      const { error: deleteError } = await deleteGoal(goalId)
+      if (deleteError) {
+        console.error("Error deleting goal:", deleteError)
+        alert(deleteError.message || "Failed to delete goal")
+        return
+      }
+
+      setGoals((prev) => {
+        const filtered = prev.filter((goal) => goal.id !== goalId)
+        if (filtered.length === 0) {
+          setSelectedGoalId("")
+        } else if (goalId === selectedGoalId) {
+          setSelectedGoalId(filtered[0].id)
+        }
+        return filtered
+      })
+      const progressMap = { ...prevProgressRef.current }
+      delete progressMap[goalId]
+      prevProgressRef.current = progressMap
+    } catch (deleteUnexpected) {
+      console.error("Unexpected error deleting goal:", deleteUnexpected)
+      alert("Unexpected error deleting goal")
+    }
+  }
+
+  const handleLinkBudgetChange = async (goal, linkedBudgetId) => {
+    try {
+      const { data, error: updateError } = await updateGoal(goal.id, {
+        linkedBudgetId: linkedBudgetId || null,
+      })
+      if (updateError) {
+        console.error("Error linking budget:", updateError)
+        alert(updateError.message || "Failed to link budget")
+        return
+      }
+
+      if (data?.[0]) {
+        const normalizedGoal = normalizeGoalRecord(data[0])
+        setGoals((prev) => prev.map((item) => (item.id === goal.id ? normalizedGoal : item)))
+      } else {
+        setGoals((prev) =>
+          prev.map((item) => (item.id === goal.id ? { ...item, linked_budget_id: linkedBudgetId || null } : item)),
+        )
+      }
+    } catch (updateUnexpected) {
+      console.error("Unexpected error linking budget:", updateUnexpected)
+      alert("Unexpected error while linking budget")
+    }
+  }
+
+  const closeKeypad = () => {
+    setKeypadOpen(false)
+    setKeypadValue("")
+    setContributionNote("")
+  }
+
+  const appendKeypadValue = (value) => {
+    setKeypadValue((prev) => {
+      if (value === "←") {
+        return prev.slice(0, -1)
+      }
+      if (value === "." && prev.includes(".")) {
+        return prev
+      }
+      return `${prev}${value}`
+    })
+  }
+
+  const handleContributionSubmit = async () => {
+    const amount = parseFloat(keypadValue)
+    if (!selectedGoalId || Number.isNaN(amount) || amount <= 0) {
+      alert("Enter a valid contribution amount")
+      return
+    }
+
+    const goal = goals.find((item) => item.id === selectedGoalId)
+    if (!goal) {
+      alert("Select a goal")
+      return
+    }
+
+    setLoggingContribution(true)
+    const contributionDate = new Date().toISOString()
+    try {
+      const previousProgress = prevProgressRef.current[goal.id] ?? getGoalMetrics(goal).progress
+      const { data, error: contributionError } = await addGoalContribution(goal.id, {
+        amount,
+        date: contributionDate,
+        note: contributionNote,
+      })
+      if (contributionError) {
+        console.error("Error logging contribution:", contributionError)
+        alert(contributionError.message || "Failed to log contribution")
+        return
+      }
+
+      const newContributions = (data || []).map(normalizeContribution)
+      if (newContributions.length) {
+        const updatedGoal = normalizeGoalRecord({
+          ...goal,
+          goal_contributions: [...newContributions, ...(goal.goal_contributions || [])],
+        })
+
+        const nextProgress = getGoalMetrics(updatedGoal).progress
+        handleMilestoneCelebration(updatedGoal, previousProgress, nextProgress)
+        prevProgressRef.current[goal.id] = nextProgress
+
+        setGoals((prev) => prev.map((item) => (item.id === goal.id ? updatedGoal : item)))
+        await syncContributionToBudget(goal, amount, contributionDate)
+      }
+
+      closeKeypad()
+    } catch (contributionUnexpected) {
+      console.error("Unexpected error adding contribution:", contributionUnexpected)
+      alert("Unexpected error adding contribution")
+    } finally {
+      setLoggingContribution(false)
+    }
+  }
+
+  const handleMilestoneCelebration = (goal, previousProgress, nextProgress) => {
+    const milestones = (goal.milestones || DEFAULT_MILESTONES).slice().sort((a, b) => a - b)
+    const unlocked = milestones.find((milestone) => previousProgress < milestone && nextProgress >= milestone)
+    if (unlocked !== undefined) {
+      setConfettiGoalId(goal.id)
+      setMilestoneCelebration({ goalName: goal.name, milestone: unlocked })
+      setTimeout(() => {
+        setConfettiGoalId(null)
+        setMilestoneCelebration(null)
+      }, 4000)
+    }
+  }
+
+  const syncContributionToBudget = async (goal, amount, date) => {
+    if (!goal.linked_budget_id || !setBudgets) {
+      return
+    }
+    const linkedBudget = budgets.find((budget) => budget.id === goal.linked_budget_id)
+    if (!linkedBudget) {
+      return
+    }
+
+    try {
+      const transactionPayload = {
+        name: `Goal Contribution - ${goal.name}`,
+        amount,
+        budgetedAmount: 0,
+        category: "Savings Goals",
+        type: "expense",
+        date,
+        receipt: null,
+      }
+      const { data, error: transactionError } = await createTransaction(goal.linked_budget_id, transactionPayload)
+      if (transactionError) {
+        console.error("Failed to sync contribution to budget:", transactionError)
+        return
+      }
+
+      const inserted = data?.[0]
+      const normalizedTransaction = inserted
+        ? {
+            id: inserted.id,
+            name: inserted.name,
+            amount: inserted.amount,
+            budgetedAmount: inserted.budgeted_amount,
+            category: inserted.category,
+            type: inserted.type,
+            date: inserted.date,
+            receipt: inserted.receipt_url,
+          }
+        : {
+            id: `goal-sync-${Date.now()}`,
+            ...transactionPayload,
+          }
+
+      setBudgets((prev) =>
+        prev.map((budget) =>
+          budget.id === goal.linked_budget_id
+            ? { ...budget, transactions: [...(budget.transactions || []), normalizedTransaction] }
+            : budget,
+        ),
+      )
+    } catch (transactionUnexpected) {
+      console.error("Unexpected error syncing contribution to budget:", transactionUnexpected)
+    }
+  }
+
+  const milestoneBadges = (goal) => {
+    const metrics = getGoalMetrics(goal)
+    const achieved = (goal.milestones || DEFAULT_MILESTONES).filter((milestone) => metrics.progress >= milestone)
+    return achieved
+  }
+
+  const keypadButtons = useMemo(
+    () => [
+      ["1", "2", "3"],
+      ["4", "5", "6"],
+      ["7", "8", "9"],
+      [".", "0", "←"],
+    ],
+    [],
+  )
+
+  return (
+    <div className="goals-screen">
+      <div className="goals-header">
+        <button className="ghost-button" onClick={() => setViewMode("budgets")}>← Budgets</button>
+        <h2>Savings Goals</h2>
+        <p className="tagline">Track milestones, weekly pace, and stay motivated.</p>
+      </div>
+
+      {error && <div className="error-banner">{error}</div>}
+
+      {loading ? (
+        <div className="loading-goals">Loading goals…</div>
+      ) : goals.length === 0 ? (
+        <div className="empty-state">
+          <p>Start a new savings goal to build momentum.</p>
+          <button className="primary-button" onClick={() => setCreating(true)}>
+            Create your first goal
+          </button>
+        </div>
+      ) : (
+        goals.map((goal) => {
+          const metrics = getGoalMetrics(goal)
+          const achievedMilestones = milestoneBadges(goal)
+          return (
+            <div key={goal.id} className="goal-card">
+              <div className="goal-card-header">
+                <div>
+                  <h3>{goal.name}</h3>
+                  <span className={`goal-pace-badge ${metrics.pace}`}>{metrics.pace.replace("-", " ")}</span>
+                  {metrics.progress >= 100 && <span className="goal-complete">🎉 Complete</span>}
+                </div>
+                <button className="icon-button" onClick={() => handleDeleteGoal(goal.id)} title="Delete goal">
+                  🗑️
+                </button>
+              </div>
+
+              <div className="goal-progress-bar">
+                <div className="goal-progress" style={{ width: `${metrics.progress}%` }} />
+              </div>
+              <div className="goal-progress-meta">
+                <span>{formatCurrency(metrics.totalContributed)} saved</span>
+                <span>Target {formatCurrency(goal.targetAmount)}</span>
+              </div>
+
+              <div className="goal-meta-grid">
+                <div>
+                  <p className="meta-label">Weekly target</p>
+                  <p className="meta-value">{formatCurrency(metrics.weeklyTarget)}</p>
+                </div>
+                <div>
+                  <p className="meta-label">This week</p>
+                  <p className="meta-value">{formatCurrency(metrics.contributedThisWeek)}</p>
+                </div>
+                {goal.targetDate && (
+                  <div>
+                    <p className="meta-label">Target date</p>
+                    <p className="meta-value">{new Date(goal.targetDate).toLocaleDateString()}</p>
+                  </div>
+                )}
+                <div>
+                  <p className="meta-label">Milestones</p>
+                  <p className="meta-value">{achievedMilestones.length > 0 ? `${achievedMilestones.join("% • ")}%` : "—"}</p>
+                </div>
+              </div>
+
+              {metrics.pace === "behind" && metrics.guidanceShortfall > 0 && (
+                <div className="goal-guidance">Add {formatCurrency(metrics.guidanceShortfall)} this week to catch up.</div>
+              )}
+
+              <div className="goal-budget-link">
+                <label>
+                  Sync with budget
+                  <select
+                    value={goal.linked_budget_id || ""}
+                    onChange={(event) => handleLinkBudgetChange(goal, event.target.value)}
+                  >
+                    <option value="">Not linked</option>
+                    {budgets.map((budget) => (
+                      <option key={budget.id} value={budget.id}>
+                        {budget.name}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              </div>
+
+              {goal.goal_contributions && goal.goal_contributions.length > 0 && (
+                <div className="goal-contributions">
+                  <h4>Recent contributions</h4>
+                  <ul>
+                    {goal.goal_contributions.slice(0, 4).map((contribution) => (
+                      <li key={contribution.id}>
+                        <span>{new Date(contribution.contributed_at).toLocaleDateString()}</span>
+                        <span>{formatCurrency(contribution.amount)}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )
+        })
+      )}
+
+      <button
+        className="fab"
+        onClick={() => {
+          if (!goals.length) {
+            setCreating(true)
+            return
+          }
+          if (!selectedGoalId && goals.length) {
+            setSelectedGoalId(goals[0].id)
+          }
+          setKeypadOpen(true)
+        }}
+        title="Log contribution"
+      >
+        ➕
+      </button>
+
+      <button className="secondary-button" onClick={() => setCreating(true)} style={{ width: "100%", marginTop: "1rem" }}>
+        New goal
+      </button>
+
+      {creating && (
+        <div className="modal-backdrop">
+          <div className="modal">
+            <h3>Create goal</h3>
+            <form onSubmit={handleCreateGoal} className="goal-form">
+              <label>
+                Goal name
+                <input
+                  type="text"
+                  value={goalForm.name}
+                  onChange={(event) => setGoalForm((prev) => ({ ...prev, name: event.target.value }))}
+                  placeholder="Emergency fund"
+                  required
+                />
+              </label>
+              <label>
+                Target amount
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={goalForm.targetAmount}
+                  onChange={(event) => setGoalForm((prev) => ({ ...prev, targetAmount: event.target.value }))}
+                  placeholder="5000"
+                  required
+                />
+              </label>
+              <label>
+                Target date
+                <input
+                  type="date"
+                  value={goalForm.targetDate}
+                  onChange={(event) => setGoalForm((prev) => ({ ...prev, targetDate: event.target.value }))}
+                />
+              </label>
+              <label>
+                Link to budget
+                <select
+                  value={goalForm.linkedBudgetId}
+                  onChange={(event) => setGoalForm((prev) => ({ ...prev, linkedBudgetId: event.target.value }))}
+                >
+                  <option value="">Not linked</option>
+                  {budgets.map((budget) => (
+                    <option key={budget.id} value={budget.id}>
+                      {budget.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <div className="modal-actions">
+                <button type="button" className="ghost-button" onClick={() => setCreating(false)}>
+                  Cancel
+                </button>
+                <button type="submit" className="primary-button" disabled={saving}>
+                  {saving ? "Saving…" : "Create"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {keypadOpen && (
+        <div className="modal-backdrop">
+          <div className="modal keypad-modal">
+            <h3>Log contribution</h3>
+            <label>
+              Choose goal
+              <select value={selectedGoalId} onChange={(event) => setSelectedGoalId(event.target.value)}>
+                {goals.map((goal) => (
+                  <option key={goal.id} value={goal.id}>
+                    {goal.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <div className="keypad-display">{keypadValue || "0"}</div>
+            <div className="numeric-keypad">
+              {keypadButtons.map((row, rowIndex) => (
+                <div key={rowIndex} className="keypad-row">
+                  {row.map((label) => (
+                    <button key={label} type="button" onClick={() => appendKeypadValue(label)}>
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              ))}
+            </div>
+            <label>
+              Note (optional)
+              <input
+                type="text"
+                value={contributionNote}
+                onChange={(event) => setContributionNote(event.target.value)}
+                placeholder="Paycheck transfer"
+              />
+            </label>
+            <div className="modal-actions">
+              <button type="button" className="ghost-button" onClick={closeKeypad}>
+                Cancel
+              </button>
+              <button type="button" className="primary-button" onClick={handleContributionSubmit} disabled={loggingContribution}>
+                {loggingContribution ? "Saving…" : "Log"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confettiGoalId && (
+        <div className="confetti-overlay">
+          {Array.from({ length: 60 }).map((_, index) => (
+            <span
+              key={index}
+              className="confetti-piece"
+              style={{
+                left: `${Math.random() * 100}%`,
+                animationDelay: `${Math.random() * 1.5}s`,
+              }}
+            >
+              🎉
+            </span>
+          ))}
+        </div>
+      )}
+
+      {milestoneCelebration && (
+        <div className="milestone-banner">
+          <strong>{milestoneCelebration.goalName}</strong> reached {milestoneCelebration.milestone}% of the goal!
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1554,6 +1554,358 @@ body {
   box-shadow: var(--shadow-lg);
 }
 
+.header-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
+}
+
+.goals-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding-bottom: 6rem;
+  position: relative;
+}
+
+.goals-header {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.25rem;
+  border: 1px solid var(--gray-200);
+  box-shadow: var(--shadow-sm);
+}
+
+.goals-header h2 {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.5rem;
+}
+
+.goals-header .tagline {
+  margin-bottom: 0;
+}
+
+.ghost-button {
+  background: none;
+  border: none;
+  color: var(--primary-600);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  margin-bottom: 0.5rem;
+}
+
+.ghost-button:hover {
+  text-decoration: underline;
+}
+
+.goal-card {
+  background: white;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--gray-200);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  position: relative;
+}
+
+.goal-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.goal-card-header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.goal-pace-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: var(--radius-full);
+  padding: 0.125rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 0.35rem;
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+
+.goal-pace-badge.ahead {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--green-600);
+}
+
+.goal-pace-badge.behind {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--red-600);
+}
+
+.goal-complete {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.75rem;
+  font-weight: 600;
+  color: var(--purple-600);
+}
+
+.icon-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.1rem;
+  transition: transform 0.2s ease;
+}
+
+.icon-button:hover {
+  transform: scale(1.1);
+}
+
+.goal-progress-bar {
+  width: 100%;
+  height: 0.75rem;
+  border-radius: var(--radius-full);
+  background: var(--gray-200);
+  overflow: hidden;
+}
+
+.goal-progress {
+  height: 100%;
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+  transition: width 0.4s ease;
+}
+
+.goal-progress-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  color: var(--gray-600);
+}
+
+.goal-meta-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.meta-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin: 0;
+  color: var(--gray-500);
+}
+
+.meta-value {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.goal-guidance {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.2);
+  color: var(--red-600);
+  padding: 0.75rem;
+  border-radius: var(--radius-lg);
+  font-weight: 600;
+}
+
+.goal-budget-link label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--gray-700);
+}
+
+.goal-budget-link select,
+.goal-form input,
+.goal-form select,
+.keypad-modal select,
+.keypad-modal input {
+  border-radius: var(--radius-md);
+  border: 1px solid var(--gray-300);
+  padding: 0.6rem 0.75rem;
+  font-size: 1rem;
+  background: var(--gray-50);
+}
+
+.goal-contributions h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+}
+
+.goal-contributions ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.goal-contributions li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--gray-700);
+}
+
+.goal-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.goal-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--gray-700);
+}
+
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  backdrop-filter: blur(2px);
+}
+
+.modal {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  width: min(420px, 90vw);
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h3 {
+  margin: 0;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.keypad-modal {
+  gap: 1.25rem;
+}
+
+.keypad-display {
+  font-size: 2.5rem;
+  text-align: center;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.5rem 0;
+}
+
+.numeric-keypad {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.keypad-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.5rem;
+}
+
+.keypad-row button {
+  background: var(--gray-100);
+  border: none;
+  border-radius: var(--radius-lg);
+  font-size: 1.5rem;
+  padding: 0.75rem 0;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease;
+}
+
+.keypad-row button:hover {
+  background: var(--primary-100);
+  transform: translateY(-2px);
+}
+
+.keypad-row button:active {
+  transform: translateY(0);
+}
+
+.confetti-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1100;
+}
+
+.confetti-piece {
+  position: absolute;
+  top: -10%;
+  font-size: 1.25rem;
+  animation: fall 2.4s linear forwards;
+}
+
+@keyframes fall {
+  0% {
+    transform: translateY(0) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(120vh) rotate(360deg);
+    opacity: 0;
+  }
+}
+
+.milestone-banner {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+  color: white;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-xl);
+  z-index: 1200;
+  font-weight: 600;
+}
+
+.loading-goals {
+  text-align: center;
+  color: var(--gray-600);
+  padding: 2rem 0;
+}
+
+.error-banner {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--red-600);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
 /* Delete button */
 .deleteButton {
   width: 2.5rem;


### PR DESCRIPTION
## Summary
- add Supabase helpers for savings goals and contribution records with demo-mode support
- implement a goals screen with weekly pacing analytics, milestone celebrations, and keypad-based contribution logging
- link goals into the existing navigation, sync logged contributions to budgets, and style the new UI

## Testing
- npm run build *(fails: `vite` CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b292fc38832e854968aa23720d30