### PR TITLE
Add cash burn analytics and paid nudge experience

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import LoginScreen from "./screens/LoginScreen"
 import LoadingScreen from "./components/LoadingScreen"
 import Header from "./components/Header"
 import InstallPrompt from "./components/InstallPrompt"
+import CashBurnScreen from "./screens/CashBurnScreen"
 
 function AppContent() {
   const { user, loading: authLoading, initializing } = useAuth()
@@ -138,6 +139,9 @@ function AppContent() {
           setBudgets={setBudgets}
           userId={user.id}
         />
+      )}
+      {viewMode === "cashBurn" && (
+        <CashBurnScreen userId={user.id} onClose={() => setViewMode("budgets")} categories={categories} />
       )}
       {viewMode === "details" && selectedBudget && (
         <BudgetDetailsScreen

--- a/src/hooks/useCashBurnAnalytics.js
+++ b/src/hooks/useCashBurnAnalytics.js
@@ -1,0 +1,368 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  createCashBurnAlert,
+  getCashBurnAlerts,
+  getCashBurnPreferences,
+  getCashBurnReports,
+  recordCashBurnAlertEvent,
+  subscribeToCashBurnAlerts,
+  updateCashBurnAlert,
+  updateCashBurnPreferences,
+} from "../lib/supabase"
+
+const POLL_INTERVAL_MS = 60 * 1000
+
+const FALLBACK_PREFERENCES = (userId) => ({
+  userId,
+  planTier: "free",
+  cadence: "weekly",
+  trackedCategories: ["Dining Out", "Rideshare", "Subscriptions"],
+  quietHours: { start: "21:00", end: "07:00" },
+  alertThresholds: { default: 150 },
+  sponsorSlot: {
+    label: "Upgrade to Pocket Budget Pro",
+    message: "Unlock proactive alerts and unlimited report history.",
+    cta: "See plans",
+    href: "https://pocketbudget.example.com/upgrade",
+  },
+})
+
+const parseTimeToMinutes = (timeString) => {
+  if (!timeString || typeof timeString !== "string") return null
+  const [hours, minutes] = timeString.split(":").map((value) => parseInt(value, 10))
+  if (Number.isNaN(hours)) return null
+  return hours * 60 + (Number.isNaN(minutes) ? 0 : minutes)
+}
+
+const isWithinQuietHours = (quietHours) => {
+  if (!quietHours) return false
+  const start = parseTimeToMinutes(quietHours.start)
+  const end = parseTimeToMinutes(quietHours.end)
+  if (start === null || end === null || start === end) return false
+
+  const now = new Date()
+  const currentMinutes = now.getHours() * 60 + now.getMinutes()
+
+  if (start < end) {
+    return currentMinutes >= start && currentMinutes < end
+  }
+
+  return currentMinutes >= start || currentMinutes < end
+}
+
+const normalizeCategoryKey = (category) => category?.toString().trim().toLowerCase() || "default"
+
+const derivePaceStatus = (report) => {
+  if (!report) return "neutral"
+  if (report.pace) return report.pace
+  if (!report.plannedBurn) return "neutral"
+
+  const variance = report.totalBurn - report.plannedBurn
+  if (variance > report.plannedBurn * 0.05) return "over"
+  if (variance < report.plannedBurn * -0.05) return "under"
+  return "on-track"
+}
+
+const attachComparisons = (reports = []) =>
+  reports.map((report, index) => {
+    const previous = reports[index + 1]
+    const delta = previous ? report.totalBurn - previous.totalBurn : 0
+    const deltaPercent = previous && previous.totalBurn ? (delta / previous.totalBurn) * 100 : null
+
+    return {
+      ...report,
+      pace: derivePaceStatus(report),
+      weekOverWeekDelta: delta,
+      weekOverWeekDeltaPercent: deltaPercent,
+    }
+  })
+
+const mergeAlert = (existingAlerts, newAlert) => {
+  const idx = existingAlerts.findIndex((alert) => alert.id === newAlert.id)
+  if (idx === -1) {
+    return [newAlert, ...existingAlerts]
+  }
+  const updated = [...existingAlerts]
+  updated[idx] = { ...updated[idx], ...newAlert }
+  return updated
+}
+
+const mapAlertPayload = (rawAlert) => {
+  if (!rawAlert) return null
+  return {
+    id: rawAlert.id,
+    userId: rawAlert.userId || rawAlert.user_id,
+    category: rawAlert.category,
+    currentBurn: rawAlert.currentBurn ?? rawAlert.current_burn,
+    threshold: rawAlert.threshold,
+    status: rawAlert.status,
+    scheduledFor: rawAlert.scheduledFor ?? rawAlert.scheduled_for,
+    lastTriggeredAt: rawAlert.lastTriggeredAt ?? rawAlert.last_triggered_at,
+    channel: rawAlert.channel || "in-app",
+    message: rawAlert.message,
+    createdAt: rawAlert.createdAt ?? rawAlert.created_at,
+  }
+}
+
+export function useCashBurnAnalytics(userId) {
+  const [loading, setLoading] = useState(true)
+  const [reports, setReports] = useState([])
+  const [preferences, setPreferences] = useState(null)
+  const [alerts, setAlerts] = useState([])
+  const [nudges, setNudges] = useState([])
+  const deliveredAlertIdsRef = useRef(new Set())
+  const preferencesRef = useRef(null)
+  const pollTimerRef = useRef(null)
+  const subscriptionCleanupRef = useRef(null)
+
+  const isPaidPlan = preferences?.planTier && preferences.planTier !== "free"
+
+  const queueNudgeForAlert = useCallback(
+    (alert) => {
+      const prefs = preferencesRef.current
+      if (!prefs || prefs.planTier === "free") return
+      if (!alert || !alert.id) return
+      if (deliveredAlertIdsRef.current.has(alert.id)) return
+      if (isWithinQuietHours(prefs.quietHours)) return
+
+      const categoryKey = normalizeCategoryKey(alert.category)
+      const threshold = prefs.alertThresholds?.[categoryKey] ?? prefs.alertThresholds?.default
+
+      if (threshold && typeof alert.currentBurn === "number" && alert.currentBurn < threshold) {
+        return
+      }
+
+      deliveredAlertIdsRef.current.add(alert.id)
+
+      const severity = threshold && alert.currentBurn >= threshold * 1.25 ? "high" : "medium"
+      const delta = threshold ? alert.currentBurn - threshold : null
+
+      setNudges((existing) => [
+        {
+          id: `${alert.id}-nudge`,
+          alertId: alert.id,
+          category: alert.category,
+          message:
+            alert.message ||
+            `Your ${alert.category ?? "cash burn"} spending is tracking ${delta ? `+$${delta.toFixed(0)}` : "over"} this week`,
+          severity,
+          createdAt: new Date().toISOString(),
+        },
+        ...existing,
+      ])
+
+      recordCashBurnAlertEvent(alert.id).catch((error) => {
+        console.error("Unable to record cash burn alert delivery", error)
+      })
+    },
+    [],
+  )
+
+  const loadReports = useCallback(async () => {
+    if (!userId) return
+    const { data, error } = await getCashBurnReports(userId)
+    if (error) {
+      console.error("Unable to load cash burn reports", error)
+      return
+    }
+    setReports(attachComparisons(data))
+  }, [userId])
+
+  const loadAlerts = useCallback(
+    async (options = { hydrateNudges: true }) => {
+      if (!userId) return
+      const { data, error } = await getCashBurnAlerts(userId)
+      if (error) {
+        console.error("Unable to load cash burn alerts", error)
+        return
+      }
+      setAlerts(data)
+
+      if (options.hydrateNudges && preferencesRef.current?.planTier !== "free") {
+        data
+          .filter((alert) => alert.status === "ready" || alert.status === "pending")
+          .forEach((alert) => queueNudgeForAlert(alert))
+      }
+    },
+    [queueNudgeForAlert, userId],
+  )
+
+  const stopPolling = () => {
+    if (pollTimerRef.current) {
+      clearInterval(pollTimerRef.current)
+      pollTimerRef.current = null
+    }
+  }
+
+  const startPolling = useCallback(() => {
+    stopPolling()
+    if (!userId) return
+    pollTimerRef.current = setInterval(() => {
+      loadAlerts({ hydrateNudges: false })
+    }, POLL_INTERVAL_MS)
+  }, [loadAlerts, userId])
+
+  const bootstrap = useCallback(async () => {
+    if (!userId) return
+    setLoading(true)
+    try {
+      const [preferencesResult, reportsResult] = await Promise.all([
+        getCashBurnPreferences(userId),
+        getCashBurnReports(userId),
+      ])
+
+      const { data: rawPreferences, error: prefsError } = preferencesResult
+
+      if (prefsError) {
+        console.error("Unable to load cash burn preferences", prefsError)
+      }
+
+      let resolvedPreferences = rawPreferences
+      if (!resolvedPreferences) {
+        const fallback = FALLBACK_PREFERENCES(userId)
+        const { data: createdPrefs, error: createError } = await updateCashBurnPreferences(userId, fallback)
+        if (createError) {
+          console.error("Unable to persist default cash burn preferences", createError)
+          resolvedPreferences = fallback
+        } else {
+          resolvedPreferences = createdPrefs || fallback
+        }
+      }
+
+      setPreferences(resolvedPreferences)
+      preferencesRef.current = resolvedPreferences
+
+      if (reportsResult.error) {
+        console.error("Unable to load cash burn reports", reportsResult.error)
+      }
+      setReports(attachComparisons(reportsResult.data || []))
+
+      await loadAlerts()
+    } finally {
+      setLoading(false)
+    }
+  }, [loadAlerts, userId])
+
+  useEffect(() => {
+    if (!userId) return () => {}
+
+    bootstrap()
+
+    startPolling()
+
+    const unsubscribe = subscribeToCashBurnAlerts(userId, (payload) => {
+      if (!payload) return
+      const eventType = payload.eventType || payload.type
+      if (eventType === "DELETE") {
+        const deletedId = payload.old?.id || payload.id
+        if (!deletedId) return
+        deliveredAlertIdsRef.current.delete(deletedId)
+        setAlerts((existing) => existing.filter((alert) => alert.id !== deletedId))
+        setNudges((existing) => existing.filter((nudge) => nudge.alertId !== deletedId))
+        return
+      }
+
+      const incoming = mapAlertPayload(payload.new || payload)
+      if (!incoming?.id) return
+
+      setAlerts((existing) => mergeAlert(existing, incoming))
+
+      if (preferencesRef.current?.planTier !== "free") {
+        queueNudgeForAlert(incoming)
+      }
+    })
+
+    subscriptionCleanupRef.current = unsubscribe
+
+    return () => {
+      stopPolling()
+      if (subscriptionCleanupRef.current) {
+        subscriptionCleanupRef.current()
+        subscriptionCleanupRef.current = null
+      }
+    }
+  }, [bootstrap, queueNudgeForAlert, startPolling, userId])
+
+  useEffect(() => {
+    preferencesRef.current = preferences
+  }, [preferences])
+
+  const savePreferences = useCallback(
+    async (updates) => {
+      if (!userId) return { data: null, error: new Error("Missing userId") }
+      const nextPreferences = { ...preferencesRef.current, ...updates, userId }
+      const { data, error } = await updateCashBurnPreferences(userId, nextPreferences)
+      if (error) {
+        console.error("Unable to update cash burn preferences", error)
+        return { data: null, error }
+      }
+      const resolved = data || nextPreferences
+      setPreferences(resolved)
+      preferencesRef.current = resolved
+      return { data: resolved, error: null }
+    },
+    [userId],
+  )
+
+  const dismissNudge = useCallback((nudgeId) => {
+    setNudges((existing) => existing.filter((nudge) => nudge.id !== nudgeId))
+  }, [])
+
+  const acknowledgeAlert = useCallback(async (alertId) => {
+    if (!alertId) return
+    const timestamp = new Date().toISOString()
+    await updateCashBurnAlert(alertId, { status: "acknowledged", lastTriggeredAt: timestamp })
+    deliveredAlertIdsRef.current.delete(alertId)
+    setAlerts((existing) =>
+      existing.map((alert) => (alert.id === alertId ? { ...alert, status: "acknowledged", lastTriggeredAt: timestamp } : alert)),
+    )
+    setNudges((existing) => existing.filter((nudge) => nudge.alertId !== alertId))
+  }, [])
+
+  const scheduleAlert = useCallback(
+    async ({ category, threshold, currentBurn, scheduledFor, message }) => {
+      if (!userId) return { data: null, error: new Error("Missing userId") }
+      const { data, error } = await createCashBurnAlert(userId, {
+        category,
+        threshold,
+        currentBurn,
+        scheduledFor,
+        message,
+        status: "pending",
+      })
+      if (!error && data) {
+        setAlerts((existing) => mergeAlert(existing, data))
+      }
+      return { data, error }
+    },
+    [userId],
+  )
+
+  const paceLegend = useMemo(
+    () => ({
+      over: { label: "Over pace", tone: "danger" },
+      "on-track": { label: "On track", tone: "success" },
+      under: { label: "Under pace", tone: "muted" },
+      neutral: { label: "Neutral", tone: "muted" },
+    }),
+    [],
+  )
+
+  return {
+    loading,
+    reports,
+    alerts,
+    nudges,
+    preferences,
+    isPaidPlan,
+    paceLegend,
+    refreshReports: loadReports,
+    refreshAlerts: loadAlerts,
+    savePreferences,
+    dismissNudge,
+    acknowledgeAlert,
+    scheduleAlert,
+  }
+}
+
+export default useCashBurnAnalytics

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -392,3 +392,459 @@ export const updateUserCategories = async (userId, categories) => {
     .select()
   return { data, error }
 }
+
+// Cash burn analytics demo storage
+let demoCashBurnReports = []
+let demoCashBurnAlerts = []
+let demoCashBurnPreferences = null
+const demoCashBurnAlertSubscribers = new Set()
+
+const seedDemoCashBurnReports = () => {
+  if (demoCashBurnReports.length > 0) return
+
+  const now = new Date()
+  const startOfWeek = (weeksAgo = 0) => {
+    const date = new Date(now)
+    const day = date.getUTCDay()
+    const diff = (day === 0 ? -6 : 1) - day - weeksAgo * 7
+    date.setUTCDate(date.getUTCDate() + diff)
+    date.setUTCHours(0, 0, 0, 0)
+    return date
+  }
+
+  const makeReport = (weeksAgo, overrides = {}) => {
+    const start = startOfWeek(weeksAgo)
+    const end = new Date(start)
+    end.setUTCDate(start.getUTCDate() + 6)
+
+    return {
+      id: `demo-report-${weeksAgo}`,
+      user_id: DEMO_ADMIN.user.id,
+      week_start: start.toISOString(),
+      week_end: end.toISOString(),
+      total_burn: overrides.total_burn ?? 740 - weeksAgo * 25,
+      planned_burn: overrides.planned_burn ?? 680,
+      pace: overrides.pace ?? (weeksAgo === 0 ? "over" : weeksAgo === 1 ? "on-track" : "under"),
+      top_leak_categories:
+        overrides.top_leak_categories ?? [
+          {
+            name: "Dining Out",
+            amount: 210 - weeksAgo * 10,
+            delta: weeksAgo === 0 ? 18 : weeksAgo === 1 ? -6 : -12,
+            sparkline: [120, 150, 170, 210 - weeksAgo * 10],
+          },
+          {
+            name: "Rideshare",
+            amount: 128 - weeksAgo * 8,
+            delta: weeksAgo === 0 ? 22 : 10 - weeksAgo * 4,
+            sparkline: [60, 80, 96, 128 - weeksAgo * 8],
+          },
+          {
+            name: "Subscriptions",
+            amount: 112,
+            delta: 0,
+            sparkline: [112, 112, 112, 112],
+          },
+        ],
+      narrative: overrides.narrative ?? "Restaurant spending is trending up compared to your plan.",
+    }
+  }
+
+  demoCashBurnReports = [makeReport(0), makeReport(1), makeReport(2)]
+}
+
+const seedDemoCashBurnAlerts = () => {
+  if (demoCashBurnAlerts.length > 0) return
+
+  const now = new Date()
+  const soon = new Date(now.getTime() + 15 * 60 * 1000)
+
+  demoCashBurnAlerts = [
+    {
+      id: "demo-alert-1",
+      user_id: DEMO_ADMIN.user.id,
+      category: "Dining Out",
+      current_burn: 210,
+      threshold: 180,
+      status: "ready",
+      scheduled_for: soon.toISOString(),
+      last_triggered_at: null,
+      channel: "in-app",
+      message: "Dining Out is pacing $30 over your weekly goal.",
+      created_at: now.toISOString(),
+    },
+    {
+      id: "demo-alert-2",
+      user_id: DEMO_ADMIN.user.id,
+      category: "Rideshare",
+      current_burn: 128,
+      threshold: 90,
+      status: "ready",
+      scheduled_for: now.toISOString(),
+      last_triggered_at: null,
+      channel: "in-app",
+      message: "Rideshare is trending 42% above last week.",
+      created_at: now.toISOString(),
+    },
+  ]
+}
+
+const getDefaultCashBurnPreferences = (userId) => ({
+  user_id: userId,
+  plan_tier: userId === DEMO_ADMIN.user.id ? "pro" : "free",
+  cadence: "weekly",
+  tracked_categories: ["Dining Out", "Rideshare", "Subscriptions"],
+  quiet_hours: { start: "21:00", end: "07:00" },
+  alert_thresholds: {
+    default: 150,
+    "dining out": 180,
+    rideshare: 90,
+  },
+  sponsor_slot: {
+    label: "Upgrade to Pocket Budget Pro",
+    message: "Unlock proactive nudges and unlimited cash burn history.",
+    cta: "See plans",
+    href: "https://pocketbudget.example.com/upgrade",
+  },
+})
+
+const notifyDemoAlertSubscribers = (payload) => {
+  demoCashBurnAlertSubscribers.forEach((callback) => {
+    try {
+      callback(payload)
+    } catch (error) {
+      console.error("Error notifying demo cash burn subscribers", error)
+    }
+  })
+}
+
+const normalizeReport = (report) => {
+  if (!report) return null
+
+  return {
+    id: report.id,
+    userId: report.user_id,
+    weekStart: report.week_start,
+    weekEnd: report.week_end,
+    totalBurn: report.total_burn,
+    plannedBurn: report.planned_burn,
+    pace: report.pace,
+    topCategories: report.top_leak_categories || report.topCategories || [],
+    narrative: report.narrative,
+    createdAt: report.created_at,
+  }
+}
+
+const normalizePreferences = (preferences) => {
+  if (!preferences) return null
+
+  return {
+    userId: preferences.user_id,
+    planTier: preferences.plan_tier,
+    cadence: preferences.cadence,
+    trackedCategories: preferences.tracked_categories || [],
+    quietHours: preferences.quiet_hours || { start: "21:00", end: "07:00" },
+    alertThresholds: preferences.alert_thresholds || {},
+    sponsorSlot: preferences.sponsor_slot,
+  }
+}
+
+const denormalizePreferences = (preferences) => ({
+  user_id: preferences.userId,
+  plan_tier: preferences.planTier,
+  cadence: preferences.cadence,
+  tracked_categories: preferences.trackedCategories,
+  quiet_hours: preferences.quietHours,
+  alert_thresholds: preferences.alertThresholds,
+  sponsor_slot: preferences.sponsorSlot,
+})
+
+const normalizeAlert = (alert) => {
+  if (!alert) return null
+
+  return {
+    id: alert.id,
+    userId: alert.user_id,
+    category: alert.category,
+    currentBurn: alert.current_burn ?? alert.currentBurn,
+    threshold: alert.threshold,
+    status: alert.status,
+    scheduledFor: alert.scheduled_for,
+    lastTriggeredAt: alert.last_triggered_at,
+    channel: alert.channel || "in-app",
+    message: alert.message,
+    createdAt: alert.created_at,
+  }
+}
+
+export const getCashBurnReports = async (userId, { limit = 6 } = {}) => {
+  if (!userId) {
+    return { data: [], error: new Error("userId is required") }
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    seedDemoCashBurnReports()
+    const reports = demoCashBurnReports.slice(0, limit).map(normalizeReport)
+    return { data: reports, error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_reports")
+    .select("*")
+    .eq("user_id", userId)
+    .order("week_start", { ascending: false })
+    .limit(limit)
+
+  return { data: data?.map(normalizeReport) ?? [], error }
+}
+
+export const upsertCashBurnReport = async (userId, report) => {
+  if (!userId) {
+    return { data: null, error: new Error("userId is required") }
+  }
+
+  const payload = {
+    id: report.id,
+    user_id: userId,
+    week_start: report.weekStart,
+    week_end: report.weekEnd,
+    total_burn: report.totalBurn,
+    planned_burn: report.plannedBurn,
+    pace: report.pace,
+    top_leak_categories: report.topCategories,
+    narrative: report.narrative,
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    seedDemoCashBurnReports()
+    if (payload.id) {
+      demoCashBurnReports = demoCashBurnReports.map((existing) =>
+        existing.id === payload.id ? { ...existing, ...payload } : existing,
+      )
+    } else {
+      const newReport = { ...payload, id: `demo-report-${Date.now()}` }
+      demoCashBurnReports = [newReport, ...demoCashBurnReports]
+      return { data: [normalizeReport(newReport)], error: null }
+    }
+    const updated = demoCashBurnReports.find((existing) => existing.id === payload.id)
+    return { data: [normalizeReport(updated)], error: null }
+  }
+
+  const { data, error } = await supabase.from("cash_burn_reports").upsert(payload).select()
+  return { data: data?.map(normalizeReport) ?? null, error }
+}
+
+export const deleteCashBurnReport = async (reportId) => {
+  if (!reportId) {
+    return { error: new Error("reportId is required") }
+  }
+
+  if (reportId.startsWith("demo-report-")) {
+    demoCashBurnReports = demoCashBurnReports.filter((report) => report.id !== reportId)
+    return { error: null }
+  }
+
+  const { error } = await supabase.from("cash_burn_reports").delete().eq("id", reportId)
+  return { error }
+}
+
+export const getCashBurnPreferences = async (userId) => {
+  if (!userId) {
+    return { data: null, error: new Error("userId is required") }
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    if (!demoCashBurnPreferences) {
+      demoCashBurnPreferences = getDefaultCashBurnPreferences(userId)
+    }
+    return { data: normalizePreferences(demoCashBurnPreferences), error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_preferences")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (error && error.code !== "PGRST116") {
+    return { data: null, error }
+  }
+
+  if (!data) {
+    return { data: null, error: null }
+  }
+
+  return { data: normalizePreferences(data), error: null }
+}
+
+export const updateCashBurnPreferences = async (userId, preferences) => {
+  if (!userId) {
+    return { data: null, error: new Error("userId is required") }
+  }
+
+  const payload = denormalizePreferences({ ...preferences, userId })
+
+  if (userId === DEMO_ADMIN.user.id) {
+    demoCashBurnPreferences = payload
+    return { data: normalizePreferences(payload), error: null }
+  }
+
+  const { data, error } = await supabase.from("cash_burn_preferences").upsert(payload).select()
+  return { data: data?.map(normalizePreferences)?.[0] ?? null, error }
+}
+
+export const getCashBurnAlerts = async (userId) => {
+  if (!userId) {
+    return { data: [], error: new Error("userId is required") }
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    seedDemoCashBurnAlerts()
+    return { data: demoCashBurnAlerts.map(normalizeAlert), error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_alerts")
+    .select("*")
+    .eq("user_id", userId)
+    .order("scheduled_for", { ascending: true })
+
+  return { data: data?.map(normalizeAlert) ?? [], error }
+}
+
+export const createCashBurnAlert = async (userId, alert) => {
+  if (!userId) {
+    return { data: null, error: new Error("userId is required") }
+  }
+
+  const payload = {
+    id: alert.id,
+    user_id: userId,
+    category: alert.category,
+    current_burn: alert.currentBurn,
+    threshold: alert.threshold,
+    status: alert.status ?? "pending",
+    scheduled_for: alert.scheduledFor,
+    last_triggered_at: alert.lastTriggeredAt,
+    channel: alert.channel || "in-app",
+    message: alert.message,
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    const newAlert = { ...payload, id: payload.id || `demo-alert-${Date.now()}` }
+    demoCashBurnAlerts = [newAlert, ...demoCashBurnAlerts]
+    notifyDemoAlertSubscribers({ type: "INSERT", new: newAlert })
+    return { data: normalizeAlert(newAlert), error: null }
+  }
+
+  const { data, error } = await supabase.from("cash_burn_alerts").insert(payload).select().single()
+  if (!error && data) {
+    return { data: normalizeAlert(data), error: null }
+  }
+  return { data: null, error }
+}
+
+export const updateCashBurnAlert = async (alertId, updates) => {
+  if (!alertId) {
+    return { data: null, error: new Error("alertId is required") }
+  }
+
+  const payload = {
+    category: updates.category,
+    current_burn: updates.currentBurn,
+    threshold: updates.threshold,
+    status: updates.status,
+    scheduled_for: updates.scheduledFor,
+    last_triggered_at: updates.lastTriggeredAt,
+    channel: updates.channel,
+    message: updates.message,
+  }
+
+  if (alertId.startsWith("demo-alert-")) {
+    demoCashBurnAlerts = demoCashBurnAlerts.map((alert) =>
+      alert.id === alertId ? { ...alert, ...payload } : alert,
+    )
+    const updated = demoCashBurnAlerts.find((alert) => alert.id === alertId)
+    notifyDemoAlertSubscribers({ type: "UPDATE", new: updated })
+    return { data: normalizeAlert(updated), error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_alerts")
+    .update(payload)
+    .eq("id", alertId)
+    .select()
+    .single()
+
+  return { data: data ? normalizeAlert(data) : null, error }
+}
+
+export const deleteCashBurnAlert = async (alertId) => {
+  if (!alertId) {
+    return { error: new Error("alertId is required") }
+  }
+
+  if (alertId.startsWith("demo-alert-")) {
+    const existing = demoCashBurnAlerts.find((alert) => alert.id === alertId)
+    demoCashBurnAlerts = demoCashBurnAlerts.filter((alert) => alert.id !== alertId)
+    notifyDemoAlertSubscribers({ type: "DELETE", old: existing })
+    return { error: null }
+  }
+
+  const { error } = await supabase.from("cash_burn_alerts").delete().eq("id", alertId)
+  return { error }
+}
+
+export const recordCashBurnAlertEvent = async (alertId) => {
+  if (!alertId) {
+    return { error: new Error("alertId is required") }
+  }
+
+  const payload = { last_triggered_at: new Date().toISOString(), status: "delivered" }
+
+  if (alertId.startsWith("demo-alert-")) {
+    demoCashBurnAlerts = demoCashBurnAlerts.map((alert) =>
+      alert.id === alertId ? { ...alert, ...payload } : alert,
+    )
+    const updated = demoCashBurnAlerts.find((alert) => alert.id === alertId)
+    notifyDemoAlertSubscribers({ type: "UPDATE", new: updated })
+    return { error: null }
+  }
+
+  const { error } = await supabase
+    .from("cash_burn_alerts")
+    .update(payload)
+    .eq("id", alertId)
+  return { error }
+}
+
+export const subscribeToCashBurnAlerts = (userId, callback) => {
+  if (!userId || typeof callback !== "function") {
+    return () => {}
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    demoCashBurnAlertSubscribers.add(callback)
+    return () => {
+      demoCashBurnAlertSubscribers.delete(callback)
+    }
+  }
+
+  const channel = supabase
+    .channel(`cash-burn-alerts-${userId}`)
+    .on(
+      "postgres_changes",
+      {
+        event: "*",
+        schema: "public",
+        table: "cash_burn_alerts",
+        filter: `user_id=eq.${userId}`,
+      },
+      (payload) => callback(payload),
+    )
+    .subscribe()
+
+  return () => {
+    supabase.removeChannel(channel)
+  }
+}

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -129,6 +129,16 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
         <p className="tagline">Manage your budgets and stay on top of your finances.</p>
       </div>
 
+      <section className="cashburn-entry-card">
+        <div>
+          <h2 className="cashburn-entry-card__title">Cash burn analytics</h2>
+          <p className="cashburn-entry-card__subtitle">Spot weekly leak categories, pace changes, and upcoming nudges.</p>
+        </div>
+        <button className="primary-button" onClick={() => setViewMode("cashBurn")} disabled={loading}>
+          View weekly report
+        </button>
+      </section>
+
       {budgets.length === 0 ? (
         <div className="empty-state">
           <p>Welcome to Pocket Budget! Create your first budget to get started.</p>

--- a/src/screens/CashBurnScreen.jsx
+++ b/src/screens/CashBurnScreen.jsx
@@ -1,0 +1,376 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import PropTypes from "prop-types"
+import useCashBurnAnalytics from "../hooks/useCashBurnAnalytics"
+
+const paceToneToClass = {
+  danger: "cashburn-pill danger",
+  success: "cashburn-pill success",
+  muted: "cashburn-pill muted",
+}
+
+const formatCurrency = (value) => {
+  if (value === null || value === undefined) return "—"
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value)
+}
+
+const formatPercent = (value) => {
+  if (value === null || value === undefined) return "—"
+  const formatter = new Intl.NumberFormat("en-US", { style: "percent", maximumFractionDigits: 1 })
+  return formatter.format(value / 100)
+}
+
+const formatWeekRange = (start, end) => {
+  if (!start) return "This week"
+  const formatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" })
+  const startDate = formatter.format(new Date(start))
+  const endDate = end ? formatter.format(new Date(end)) : "present"
+  return `${startDate} – ${endDate}`
+}
+
+const sparkLinePoints = (values = []) => {
+  if (!Array.isArray(values) || values.length === 0) return []
+  const max = Math.max(...values)
+  const min = Math.min(...values)
+  const range = max - min || 1
+  return values.map((value) => ((value - min) / range) * 100)
+}
+
+const SettingsSheet = ({
+  isOpen,
+  onClose,
+  preferences,
+  categories,
+  onSave,
+}) => {
+  const expenseCategories = useMemo(() => categories?.expense?.map((cat) => cat.name) || [], [categories])
+  const [trackedCategories, setTrackedCategories] = useState(preferences?.trackedCategories || [])
+  const [cadence, setCadence] = useState(preferences?.cadence || "weekly")
+  const [planTier, setPlanTier] = useState(preferences?.planTier || "free")
+  const [quietStart, setQuietStart] = useState(preferences?.quietHours?.start || "21:00")
+  const [quietEnd, setQuietEnd] = useState(preferences?.quietHours?.end || "07:00")
+  const [thresholds, setThresholds] = useState(preferences?.alertThresholds || { default: 150 })
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    if (!isOpen || !preferences) return
+    setTrackedCategories(preferences.trackedCategories || [])
+    setCadence(preferences.cadence || "weekly")
+    setPlanTier(preferences.planTier || "free")
+    setQuietStart(preferences.quietHours?.start || "21:00")
+    setQuietEnd(preferences.quietHours?.end || "07:00")
+    setThresholds(preferences.alertThresholds || { default: 150 })
+  }, [isOpen, preferences])
+
+  const toggleCategory = (name) => {
+    setTrackedCategories((current) =>
+      current.includes(name) ? current.filter((category) => category !== name) : [...current, name],
+    )
+  }
+
+  const handleThresholdChange = (key, value) => {
+    setThresholds((current) => ({
+      ...current,
+      [key]: value === "" ? "" : Number(value),
+    }))
+  }
+
+  const handleSave = async (event) => {
+    event.preventDefault()
+    setSaving(true)
+    try {
+      const alertThresholds = { ...thresholds }
+      trackedCategories.forEach((category) => {
+        const key = category.toLowerCase()
+        if (alertThresholds[key] === undefined || alertThresholds[key] === "") {
+          alertThresholds[key] = alertThresholds.default || 150
+        }
+      })
+      const result = await onSave({
+        planTier,
+        cadence,
+        trackedCategories,
+        quietHours: { start: quietStart, end: quietEnd },
+        alertThresholds,
+      })
+      if (result?.error) {
+        console.error("Unable to save cash burn preferences", result.error)
+        alert("We couldn't save your cash burn settings. Please try again.")
+        return
+      }
+      onClose()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="cashburn-sheet-backdrop" role="dialog" aria-modal="true">
+      <form className="cashburn-sheet" onSubmit={handleSave}>
+        <header className="cashburn-sheet__header">
+          <h2>Cash Burn settings</h2>
+          <button type="button" className="icon-button" onClick={onClose} aria-label="Close settings">
+            ✕
+          </button>
+        </header>
+
+        <div className="cashburn-sheet__content">
+          <section>
+            <h3>Plan</h3>
+            <p className="cashburn-sheet__hint">Paid plans unlock proactive nudges and advanced pacing controls.</p>
+            <select className="input" value={planTier} onChange={(event) => setPlanTier(event.target.value)}>
+              <option value="free">Free</option>
+              <option value="pro">Pro</option>
+              <option value="teams">Teams</option>
+            </select>
+          </section>
+
+          <section>
+            <h3>Report cadence</h3>
+            <select className="input" value={cadence} onChange={(event) => setCadence(event.target.value)}>
+              <option value="weekly">Weekly (recommended)</option>
+              <option value="biweekly">Every 2 weeks</option>
+              <option value="monthly">Monthly</option>
+            </select>
+          </section>
+
+          <section>
+            <h3>Tracked categories</h3>
+            <div className="cashburn-chip-group">
+              {(expenseCategories.length ? expenseCategories : trackedCategories).map((category) => {
+                const isActive = trackedCategories.includes(category)
+                return (
+                  <button
+                    key={category}
+                    type="button"
+                    className={`cashburn-chip ${isActive ? "active" : ""}`}
+                    onClick={() => toggleCategory(category)}
+                  >
+                    {isActive ? "✓" : ""} {category}
+                  </button>
+                )
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h3>Quiet hours</h3>
+            <div className="cashburn-quiet-hours">
+              <label>
+                Start
+                <input type="time" className="input" value={quietStart} onChange={(event) => setQuietStart(event.target.value)} />
+              </label>
+              <label>
+                End
+                <input type="time" className="input" value={quietEnd} onChange={(event) => setQuietEnd(event.target.value)} />
+              </label>
+            </div>
+          </section>
+
+          <section>
+            <h3>Alert thresholds</h3>
+            <div className="cashburn-thresholds">
+              <label>
+                Default threshold
+                <input
+                  type="number"
+                  min="0"
+                  className="input"
+                  value={thresholds.default ?? 150}
+                  onChange={(event) => handleThresholdChange("default", event.target.value)}
+                />
+              </label>
+              {trackedCategories.map((category) => {
+                const key = category.toLowerCase()
+                return (
+                  <label key={key}>
+                    {category}
+                    <input
+                      type="number"
+                      min="0"
+                      className="input"
+                      value={thresholds[key] ?? ""}
+                      onChange={(event) => handleThresholdChange(key, event.target.value)}
+                    />
+                  </label>
+                )
+              })}
+            </div>
+          </section>
+        </div>
+
+        <footer className="cashburn-sheet__footer">
+          <button type="button" className="secondary-button" onClick={onClose} disabled={saving}>
+            Cancel
+          </button>
+          <button type="submit" className="primary-button" disabled={saving}>
+            {saving ? "Saving…" : "Save settings"}
+          </button>
+        </footer>
+      </form>
+    </div>
+  )
+}
+
+SettingsSheet.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  preferences: PropTypes.object,
+  categories: PropTypes.object,
+  onSave: PropTypes.func.isRequired,
+}
+
+export default function CashBurnScreen({ userId, onClose, categories }) {
+  const { reports, preferences, nudges, loading, paceLegend, isPaidPlan, savePreferences, dismissNudge, acknowledgeAlert } =
+    useCashBurnAnalytics(userId)
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+
+  const trackedCategories = preferences?.trackedCategories || []
+
+  const legendTone = (pace) => paceLegend?.[pace]?.tone || paceLegend?.neutral?.tone || "muted"
+  const legendLabel = (pace) => paceLegend?.[pace]?.label || paceLegend?.neutral?.label || "Neutral"
+
+  return (
+    <div className="cashburn-screen">
+      <div className="cashburn-screen__header">
+        <button className="secondary-button" onClick={onClose}>
+          ← Back
+        </button>
+        <h1>Weekly cash burn</h1>
+        <button className="icon-button" onClick={() => setIsSettingsOpen(true)} aria-label="Edit cash burn settings">
+          ⚙️
+        </button>
+      </div>
+
+      {loading && <div className="cashburn-loading">Loading cash burn analytics…</div>}
+
+      {!isPaidPlan && preferences?.sponsorSlot && (
+        <aside className="cashburn-sponsor">
+          <div>
+            <p className="cashburn-sponsor__eyebrow">Sponsored</p>
+            <h2>{preferences.sponsorSlot.label}</h2>
+            <p>{preferences.sponsorSlot.message}</p>
+          </div>
+          <a className="primary-button" href={preferences.sponsorSlot.href} target="_blank" rel="noreferrer">
+            {preferences.sponsorSlot.cta}
+          </a>
+        </aside>
+      )}
+
+      {nudges.length > 0 && (
+        <section className="cashburn-nudges">
+          <h2>Nudges</h2>
+          {nudges.map((nudge) => (
+            <article key={nudge.id} className={`cashburn-nudge ${nudge.severity}`}>
+              <div>
+                <p className="cashburn-nudge__title">{nudge.category || "Cash burn"}</p>
+                <p className="cashburn-nudge__message">{nudge.message}</p>
+              </div>
+              <div className="cashburn-nudge__actions">
+                <button className="secondary-button" onClick={() => dismissNudge(nudge.id)}>
+                  Remind me later
+                </button>
+                <button className="primary-button" onClick={() => acknowledgeAlert(nudge.alertId)}>
+                  Mark resolved
+                </button>
+              </div>
+            </article>
+          ))}
+        </section>
+      )}
+
+      <section className="cashburn-reports">
+        <header className="cashburn-reports__header">
+          <h2>Weekly pace</h2>
+          {trackedCategories.length > 0 && <p className="cashburn-reports__subhead">Tracking {trackedCategories.join(", ")}</p>}
+        </header>
+
+        {reports.map((report) => {
+          const toneClass = paceToneToClass[legendTone(report.pace)] || paceToneToClass.muted
+          const delta = report.weekOverWeekDelta ?? 0
+          const deltaPercent = report.weekOverWeekDeltaPercent
+          const arrow = delta > 0 ? "▲" : delta < 0 ? "▼" : "→"
+
+          return (
+            <article key={report.id} className="cashburn-card">
+              <div className="cashburn-card__header">
+                <div>
+                  <p className="cashburn-card__eyebrow">{formatWeekRange(report.weekStart, report.weekEnd)}</p>
+                  <h3>{formatCurrency(report.totalBurn)}</h3>
+                </div>
+                <span className={toneClass}>{legendLabel(report.pace)}</span>
+              </div>
+
+              <div className="cashburn-card__body">
+                <div className="cashburn-metric">
+                  <span className="cashburn-metric__label">Plan</span>
+                  <span className="cashburn-metric__value">{formatCurrency(report.plannedBurn)}</span>
+                </div>
+                <div className="cashburn-metric">
+                  <span className="cashburn-metric__label">WoW delta</span>
+                  <span className={`cashburn-metric__value ${delta > 0 ? "bad" : delta < 0 ? "good" : "neutral"}`}>
+                    {arrow} {formatCurrency(Math.abs(delta))}
+                    {deltaPercent !== null && <span className="cashburn-metric__percent">({formatPercent(deltaPercent)})</span>}
+                  </span>
+                </div>
+              </div>
+
+              <ul className="cashburn-leaks">
+                {(report.topCategories || []).map((category) => {
+                  const spark = sparkLinePoints(category.sparkline)
+                  const leakDelta = category.delta ?? 0
+                  const leakArrow = leakDelta > 0 ? "▲" : leakDelta < 0 ? "▼" : "→"
+                  return (
+                    <li key={category.name} className="cashburn-leak">
+                      <div className="cashburn-leak__title">
+                        <span>{category.name}</span>
+                        <strong>{formatCurrency(category.amount)}</strong>
+                      </div>
+                      <div className="cashburn-leak__meta">
+                        <span className={`cashburn-leak__delta ${leakDelta > 0 ? "bad" : leakDelta < 0 ? "good" : "neutral"}`}>
+                          {leakArrow} {formatCurrency(Math.abs(leakDelta))}
+                        </span>
+                        {spark.length > 0 && (
+                          <div className="cashburn-sparkline" aria-hidden="true">
+                            {spark.map((value, index) => (
+                              <span key={index} style={{ height: `${value}%` }} />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    </li>
+                  )
+                })}
+              </ul>
+
+              {report.narrative && <p className="cashburn-card__narrative">{report.narrative}</p>}
+            </article>
+          )
+        })}
+
+        {reports.length === 0 && !loading && (
+          <div className="cashburn-empty">
+            <p>No weekly reports yet. We will compile your first snapshot after a full week of activity.</p>
+          </div>
+        )}
+      </section>
+
+      <SettingsSheet
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        preferences={preferences}
+        categories={categories}
+        onSave={savePreferences}
+      />
+    </div>
+  )
+}
+
+CashBurnScreen.propTypes = {
+  userId: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+  categories: PropTypes.object,
+}

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -122,6 +122,409 @@
   background: rgba(255, 255, 255, 0.1);
 }
 
+/* Cash burn analytics */
+.cashburn-entry-card {
+  margin: 1.5rem 0;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(124, 58, 237, 0.12));
+  border: 1px solid rgba(14, 165, 233, 0.15);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.cashburn-entry-card__title {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+}
+
+.cashburn-entry-card__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--gray-600);
+}
+
+.cashburn-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding-bottom: 3rem;
+}
+
+.cashburn-screen__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cashburn-screen__header h1 {
+  flex: 1;
+  text-align: center;
+  margin: 0;
+}
+
+.cashburn-loading {
+  background: white;
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-sm);
+  font-size: 0.95rem;
+}
+
+.cashburn-sponsor {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: var(--radius-xl);
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+  color: white;
+  box-shadow: var(--shadow-lg);
+}
+
+.cashburn-sponsor__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  margin: 0 0 0.35rem 0;
+  opacity: 0.8;
+}
+
+.cashburn-nudges {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-nudges h2 {
+  margin: 0;
+}
+
+.cashburn-nudge {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: white;
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--gray-200);
+  box-shadow: var(--shadow-sm);
+}
+
+.cashburn-nudge.high {
+  border-color: var(--red-500);
+}
+
+.cashburn-nudge.medium {
+  border-color: var(--primary-500);
+}
+
+.cashburn-nudge__title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.cashburn-nudge__message {
+  margin: 0;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+.cashburn-nudge__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.cashburn-reports {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cashburn-reports__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.cashburn-reports__header h2 {
+  margin: 0;
+}
+
+.cashburn-reports__subhead {
+  margin: 0;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+.cashburn-card {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cashburn-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cashburn-card__eyebrow {
+  margin: 0;
+  color: var(--gray-500);
+  font-size: 0.85rem;
+}
+
+.cashburn-card__body {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.cashburn-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 140px;
+}
+
+.cashburn-metric__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--gray-500);
+}
+
+.cashburn-metric__value {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.cashburn-metric__value.bad {
+  color: var(--red-600);
+}
+
+.cashburn-metric__value.good {
+  color: var(--green-600);
+}
+
+.cashburn-metric__percent {
+  margin-left: 0.25rem;
+  font-size: 0.8rem;
+  color: inherit;
+}
+
+.cashburn-leaks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-leak__title {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.cashburn-leak__meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.cashburn-leak__delta.bad {
+  color: var(--red-600);
+}
+
+.cashburn-leak__delta.good {
+  color: var(--green-600);
+}
+
+.cashburn-leak__delta.neutral {
+  color: var(--gray-500);
+}
+
+.cashburn-sparkline {
+  display: flex;
+  gap: 2px;
+  align-items: flex-end;
+  height: 36px;
+}
+
+.cashburn-sparkline span {
+  width: 6px;
+  background: linear-gradient(180deg, var(--primary-500), var(--purple-600));
+  border-radius: var(--radius-sm);
+}
+
+.cashburn-card__narrative {
+  margin: 0;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+.cashburn-empty {
+  text-align: center;
+  padding: 1.5rem;
+  border-radius: var(--radius-lg);
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+
+.cashburn-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.cashburn-pill.danger {
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--red-600);
+}
+
+.cashburn-pill.success {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--green-600);
+}
+
+.cashburn-pill.muted {
+  background: rgba(107, 114, 128, 0.12);
+  color: var(--gray-600);
+}
+
+.cashburn-sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  justify-content: center;
+  align-items: flex-end;
+  padding: 1.5rem;
+  z-index: 1100;
+}
+
+.cashburn-sheet {
+  width: 100%;
+  max-width: 480px;
+  background: white;
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+}
+
+.cashburn-sheet__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem 0.75rem;
+}
+
+.cashburn-sheet__header h2 {
+  margin: 0;
+}
+
+.cashburn-sheet__content {
+  padding: 0 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.cashburn-sheet__content section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-sheet__content h3 {
+  margin: 0;
+}
+
+.cashburn-sheet__hint {
+  margin: 0;
+  color: var(--gray-500);
+  font-size: 0.85rem;
+}
+
+.cashburn-sheet__footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.cashburn-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.cashburn-chip {
+  border: 1px solid var(--gray-300);
+  background: white;
+  border-radius: var(--radius-full);
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.cashburn-chip.active {
+  background: rgba(14, 165, 233, 0.15);
+  border-color: var(--primary-500);
+  color: var(--primary-700);
+  font-weight: 600;
+}
+
+.cashburn-quiet-hours {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.cashburn-quiet-hours label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.cashburn-thresholds {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.cashburn-thresholds label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
 /* PWA Standalone Mode Adjustments */
 @media (display-mode: standalone) {
   body {


### PR DESCRIPTION
## Summary
- add Supabase helpers for cash burn reports, preferences, and alerts with seeded demo data and realtime subscriptions
- introduce a cash burn analytics hook that hydrates reports, respects quiet hours, and delivers paid-only nudges
- build a weekly cash burn screen with stacked insights, sponsor placement, configurable settings, and an entry point from the budgets dashboard

## Testing
- npm run lint *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b81466c8832e92803b3cc44a7569