### PR TITLE
Add weekly cash burn analytics

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,8 +1,21 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { AuthProvider, useAuth } from "./contexts/AuthContext"
-import { getBudgets, getUserCategories, updateUserCategories } from "./lib/supabase"
+import {
+  getBudgets,
+  getUserCategories,
+  updateUserCategories,
+  DEFAULT_CASH_BURN_PREFERENCES,
+  calculateWeeklyCashBurn,
+  getCashBurnPreferences,
+  upsertCashBurnPreferences,
+  getCashBurnReports,
+  upsertCashBurnReport,
+  getCashBurnAlerts,
+  logCashBurnAlert,
+  subscribeToCashBurnAlerts,
+} from "./lib/supabase"
 import BudgetsScreen from "./screens/BudgetsScreen"
 import BudgetDetailsScreen from "./screens/BudgetDetailsScreen"
 import CategoriesScreen from "./screens/CategoriesScreen"
@@ -11,6 +24,44 @@ import LoginScreen from "./screens/LoginScreen"
 import LoadingScreen from "./components/LoadingScreen"
 import Header from "./components/Header"
 import InstallPrompt from "./components/InstallPrompt"
+
+const parseTimeToMinutes = (value) => {
+  if (!value || typeof value !== "string") return null
+  const [hours, minutes] = value.split(":").map((part) => Number.parseInt(part, 10))
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) return null
+  return hours * 60 + minutes
+}
+
+const isWithinQuietHours = (date, quietHours) => {
+  if (!quietHours) return false
+  const startMinutes = parseTimeToMinutes(quietHours.start)
+  const endMinutes = parseTimeToMinutes(quietHours.end)
+  if (startMinutes === null || endMinutes === null) return false
+
+  const minutes = date.getHours() * 60 + date.getMinutes()
+
+  if (startMinutes === endMinutes) {
+    return false
+  }
+
+  if (startMinutes < endMinutes) {
+    return minutes >= startMinutes && minutes < endMinutes
+  }
+
+  return minutes >= startMinutes || minutes < endMinutes
+}
+
+const deriveAlertKey = (alert) => {
+  if (!alert) return ""
+  const weekStart = alert.week_start || alert.weekStart || ""
+  const category = alert.category || "general"
+  const ratio = Number.isFinite(alert.pace_ratio)
+    ? Number(alert.pace_ratio).toFixed(3)
+    : Number.isFinite(alert.paceRatio)
+    ? Number(alert.paceRatio).toFixed(3)
+    : "1.000"
+  return `${weekStart}:${category}:${ratio}`
+}
 
 function AppContent() {
   const { user, loading: authLoading, initializing } = useAuth()
@@ -35,6 +86,13 @@ function AppContent() {
   const [selectedBudget, setSelectedBudget] = useState(null)
   const [viewMode, setViewMode] = useState("budgets")
   const [isLoading, setIsLoading] = useState(false)
+  const [cashBurnPreferences, setCashBurnPreferences] = useState(DEFAULT_CASH_BURN_PREFERENCES)
+  const [cashBurnReport, setCashBurnReport] = useState(null)
+  const [cashBurnHistory, setCashBurnHistory] = useState([])
+  const [cashBurnAlerts, setCashBurnAlerts] = useState([])
+  const [activeNudges, setActiveNudges] = useState([])
+  const lastReportSignatureRef = useRef(null)
+  const deliveredAlertKeysRef = useRef(new Set())
 
   // Load user data when authenticated
   useEffect(() => {
@@ -46,41 +104,60 @@ function AppContent() {
   const loadUserData = async () => {
     try {
       setIsLoading(true)
+      const [budgetsResult, categoriesResult, preferencesResult, reportsResult, alertsResult] = await Promise.all([
+        getBudgets(user.id),
+        getUserCategories(user.id),
+        getCashBurnPreferences(user.id),
+        getCashBurnReports(user.id),
+        getCashBurnAlerts(user.id, { limit: 20 }),
+      ])
 
-      // Load budgets
-      const { data: budgetsData, error: budgetsError } = await getBudgets(user.id)
-      if (budgetsError) {
-        console.error("Error loading budgets:", budgetsError)
-      } else {
-        // Transform the data to match the existing structure
-        const transformedBudgets =
-          budgetsData?.map((budget) => ({
-            id: budget.id,
-            name: budget.name,
-            createdAt: new Date(budget.created_at).toLocaleDateString(),
-            categoryBudgets: budget.category_budgets || [],
-            transactions:
-              budget.transactions?.map((tx) => ({
-                id: tx.id,
-                name: tx.name,
-                amount: tx.amount,
-                budgetedAmount: tx.budgeted_amount,
-                category: tx.category,
-                type: tx.type,
-                date: tx.date,
-                receipt: tx.receipt_url,
-              })) || [],
-          })) || []
-
-        setBudgets(transformedBudgets)
+      if (budgetsResult.error) {
+        console.error("Error loading budgets:", budgetsResult.error)
       }
 
-      // Load user categories
-      const { data: categoriesData, error: categoriesError } = await getUserCategories(user.id)
-      if (categoriesError && categoriesError.code !== "PGRST116") {
-        console.error("Error loading categories:", categoriesError)
-      } else if (categoriesData?.categories) {
-        setCategories(categoriesData.categories)
+      const transformedBudgets =
+        budgetsResult.data?.map((budget) => ({
+          id: budget.id,
+          name: budget.name,
+          createdAt: new Date(budget.created_at).toLocaleDateString(),
+          categoryBudgets: budget.category_budgets || [],
+          transactions:
+            budget.transactions?.map((tx) => ({
+              id: tx.id,
+              name: tx.name,
+              amount: tx.amount,
+              budgetedAmount: tx.budgeted_amount,
+              category: tx.category,
+              type: tx.type,
+              date: tx.date,
+              receipt: tx.receipt_url,
+            })) || [],
+        })) || []
+
+      setBudgets(transformedBudgets)
+
+      if (categoriesResult.error && categoriesResult.error.code !== "PGRST116") {
+        console.error("Error loading categories:", categoriesResult.error)
+      } else if (categoriesResult.data?.categories) {
+        setCategories(categoriesResult.data.categories)
+      }
+
+      if (!preferencesResult.error && preferencesResult.data) {
+        setCashBurnPreferences(preferencesResult.data)
+      }
+
+      if (!reportsResult.error && reportsResult.data) {
+        setCashBurnHistory(reportsResult.data)
+      }
+
+      if (!alertsResult.error && alertsResult.data) {
+        setCashBurnAlerts(alertsResult.data)
+        alertsResult.data.forEach((alert) => {
+          deliveredAlertKeysRef.current.add(deriveAlertKey(alert))
+        })
+        const realtimeAlerts = alertsResult.data.filter((alert) => alert.delivery === "realtime")
+        setActiveNudges(realtimeAlerts.slice(0, 5))
       }
     } catch (error) {
       console.error("Error loading user data:", error)
@@ -99,6 +176,184 @@ function AppContent() {
       }
     }
   }
+
+  const handleCashBurnPreferencesSave = async (updatedPreferences) => {
+    if (!user) return
+
+    const nextPreferences = {
+      ...cashBurnPreferences,
+      ...updatedPreferences,
+    }
+
+    const { data, error } = await upsertCashBurnPreferences(user.id, nextPreferences)
+    if (error) {
+      console.error("Error updating cash burn preferences:", error)
+      throw error
+    }
+    setCashBurnPreferences(data || nextPreferences)
+  }
+
+  const handleDismissNudge = (nudgeId) => {
+    setActiveNudges((prev) => prev.filter((nudge) => nudge.id !== nudgeId))
+  }
+
+  // Keep recent alert keys in sync with the active reporting week to avoid duplicate nudges
+  useEffect(() => {
+    const weekStart = cashBurnReport?.weekRange?.start
+    if (!weekStart) return
+    const filtered = Array.from(deliveredAlertKeysRef.current).filter((key) => key.startsWith(`${weekStart}:`))
+    deliveredAlertKeysRef.current = new Set(filtered)
+  }, [cashBurnReport?.weekRange?.start])
+
+  // Generate weekly cash burn report and persist it
+  useEffect(() => {
+    if (!user) return
+
+    const { ui, record } = calculateWeeklyCashBurn(budgets, cashBurnPreferences)
+    setCashBurnReport(ui)
+
+    if (!ui) return
+
+    const signature = `${ui.weekRange.start}|${ui.totalBurn}|${ui.pace.ratio}|${ui.categories
+      .map((category) => `${category.name}:${category.amount}`)
+      .join(";")}`
+
+    if (signature === lastReportSignatureRef.current) {
+      return
+    }
+
+    lastReportSignatureRef.current = signature
+
+    const persistReport = async () => {
+      try {
+        const { data, error } = await upsertCashBurnReport(user.id, record)
+        if (error) {
+          console.error("Error saving cash burn report:", error)
+          return
+        }
+        if (data) {
+          setCashBurnHistory((prev) => {
+            const filtered = prev.filter((item) => item.weekRange.start !== data.weekRange.start)
+            const updated = [data, ...filtered]
+            return updated.sort((a, b) => (a.weekRange.start < b.weekRange.start ? 1 : -1))
+          })
+        }
+      } catch (error) {
+        console.error("Failed to persist cash burn report:", error)
+      }
+    }
+
+    persistReport()
+  }, [user, budgets, cashBurnPreferences])
+
+  // Subscribe to new alerts via Supabase realtime or demo events
+  useEffect(() => {
+    if (!user) return
+
+    const subscription = subscribeToCashBurnAlerts(user.id, (alert) => {
+      setCashBurnAlerts((prev) => {
+        if (prev.some((existing) => existing.id === alert.id)) {
+          return prev
+        }
+        return [alert, ...prev]
+      })
+
+      deliveredAlertKeysRef.current.add(deriveAlertKey(alert))
+
+      if (alert.delivery === "realtime") {
+        setActiveNudges((prev) => {
+          if (prev.some((existing) => existing.id === alert.id)) {
+            return prev
+          }
+          return [alert, ...prev].slice(0, 5)
+        })
+      }
+    })
+
+    return () => subscription?.unsubscribe?.()
+  }, [user])
+
+  // Paid plan polling for real-time nudges that respect quiet hours and thresholds
+  useEffect(() => {
+    if (!user) return
+    if (cashBurnPreferences.planTier !== "paid" || !cashBurnPreferences.realtimeEnabled) {
+      return
+    }
+
+    const intervalMs = Math.max(1, Number(cashBurnPreferences.pollIntervalMinutes) || 15) * 60 * 1000
+
+    let cancelled = false
+
+    const evaluateCashBurn = async (delivery = "realtime") => {
+      if (cancelled) return
+
+      const { ui } = calculateWeeklyCashBurn(budgets, cashBurnPreferences)
+      if (!ui?.thresholdBreached || !ui.leakCategories?.length) {
+        return
+      }
+
+      if (isWithinQuietHours(new Date(), cashBurnPreferences.quietHours)) {
+        return
+      }
+
+      const primaryLeak = ui.leakCategories[0]
+      const key = deriveAlertKey({
+        week_start: ui.weekRange.start,
+        category: primaryLeak?.name,
+        pace_ratio: ui.pace.ratio,
+      })
+
+      if (deliveredAlertKeysRef.current.has(key)) {
+        return
+      }
+
+      deliveredAlertKeysRef.current.add(key)
+
+      const overpacePercent = Math.max(0, Math.round((ui.pace.ratio - 1) * 100))
+      const baseAlert = {
+        id: `nudge-${Date.now()}`,
+        message: `Spending pace is ${overpacePercent}% above plan. ${
+          primaryLeak ? `${primaryLeak.name} is leading the leak.` : ""
+        }`.trim(),
+        severity: overpacePercent > 30 ? "critical" : overpacePercent > 15 ? "warning" : "info",
+        category: primaryLeak?.name || null,
+        paceRatio: ui.pace.ratio,
+        quietHoursRespected: true,
+        delivery,
+        createdAt: new Date().toISOString(),
+        weekStart: ui.weekRange.start,
+        weekEnd: ui.weekRange.end,
+      }
+
+      try {
+        const { data, error } = await logCashBurnAlert(user.id, baseAlert)
+        if (error) {
+          console.error("Failed to record cash burn alert:", error)
+          return
+        }
+
+        const persisted = data || baseAlert
+        setCashBurnAlerts((prev) => {
+          const filtered = prev.filter((alert) => alert.id !== persisted.id)
+          return [persisted, ...filtered]
+        })
+        setActiveNudges((prev) => {
+          const filtered = prev.filter((alert) => alert.id !== persisted.id)
+          return [persisted, ...filtered].slice(0, 5)
+        })
+      } catch (error) {
+        console.error("Error logging cash burn alert:", error)
+      }
+    }
+
+    evaluateCashBurn("realtime")
+    const interval = setInterval(() => evaluateCashBurn("poll"), intervalMs)
+
+    return () => {
+      cancelled = true
+      clearInterval(interval)
+    }
+  }, [user, budgets, cashBurnPreferences])
 
   // Show loading screen only during initial auth check (with timeout protection)
   if (initializing) {
@@ -137,6 +392,12 @@ function AppContent() {
           setViewMode={setViewMode}
           setBudgets={setBudgets}
           userId={user.id}
+          cashBurnReport={cashBurnReport}
+          cashBurnHistory={cashBurnHistory}
+          cashBurnPreferences={cashBurnPreferences}
+          onSaveCashBurnPreferences={handleCashBurnPreferencesSave}
+          activeNudges={activeNudges}
+          onDismissNudge={handleDismissNudge}
         />
       )}
       {viewMode === "details" && selectedBudget && (

--- a/src/components/CashBurnDashboard.jsx
+++ b/src/components/CashBurnDashboard.jsx
@@ -1,0 +1,341 @@
+import { useEffect, useMemo, useState } from "react"
+import { DEFAULT_CASH_BURN_PREFERENCES } from "../lib/supabase"
+
+const DAY_OPTIONS = [
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+  "Sunday",
+]
+
+const formatCurrency = (value) => {
+  const formatter = new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  })
+  return formatter.format(Number.isFinite(value) ? value : 0)
+}
+
+const formatPercent = (value, options = {}) => {
+  if (!Number.isFinite(value)) return "—"
+  const percentage = value * 100
+  const sign = options.showSign ? (percentage > 0 ? "+" : percentage < 0 ? "-" : "") : ""
+  return `${sign}${Math.abs(percentage).toFixed(options.decimals ?? 0)}%`
+}
+
+const Sparkline = ({ data }) => {
+  const sanitized = Array.isArray(data) ? data : []
+  const max = sanitized.reduce((acc, value) => (value > acc ? value : acc), 0)
+  if (sanitized.length === 0) {
+    return <div className="sparkline sparkline--empty" aria-hidden="true" />
+  }
+
+  const points = sanitized
+    .map((value, index) => {
+      const x = sanitized.length === 1 ? 0 : (index / (sanitized.length - 1)) * 100
+      const y = max > 0 ? 100 - (value / max) * 100 : 100
+      return `${x},${Math.max(0, Math.min(100, y))}`
+    })
+    .join(" ")
+
+  return (
+    <svg className="sparkline" viewBox="0 0 100 100" preserveAspectRatio="none" role="img" aria-hidden="true">
+      <polyline points={points} className="sparkline-path" />
+    </svg>
+  )
+}
+
+const HistorySparkline = ({ history }) => {
+  const totals = history.map((entry) => entry.totalBurn || 0).reverse()
+  return <Sparkline data={totals} />
+}
+
+export default function CashBurnDashboard({
+  report,
+  history = [],
+  preferences = DEFAULT_CASH_BURN_PREFERENCES,
+  onSavePreferences,
+  activeNudges = [],
+  onDismissNudge,
+}) {
+  const [localPreferences, setLocalPreferences] = useState(preferences)
+  const [saving, setSaving] = useState(false)
+  const [hasChanges, setHasChanges] = useState(false)
+
+  useEffect(() => {
+    setLocalPreferences(preferences)
+    setHasChanges(false)
+  }, [preferences])
+
+  const leakCategories = useMemo(() => report?.leakCategories || [], [report])
+  const resolvedPreferences = useMemo(
+    () => ({
+      ...DEFAULT_CASH_BURN_PREFERENCES,
+      ...localPreferences,
+      quietHours: {
+        ...DEFAULT_CASH_BURN_PREFERENCES.quietHours,
+        ...(localPreferences?.quietHours || {}),
+      },
+    }),
+    [localPreferences],
+  )
+
+  const isPaidPlan = (resolvedPreferences.planTier || DEFAULT_CASH_BURN_PREFERENCES.planTier) === "paid"
+
+  const handleFieldChange = (field, value) => {
+    setLocalPreferences((prev) => {
+      const updated = { ...prev, [field]: value }
+      setHasChanges(true)
+      return updated
+    })
+  }
+
+  const handleQuietHoursChange = (field, value) => {
+    setLocalPreferences((prev) => {
+      const quietHours = {
+        ...(prev?.quietHours || DEFAULT_CASH_BURN_PREFERENCES.quietHours),
+        [field]: value,
+      }
+      setHasChanges(true)
+      return { ...prev, quietHours }
+    })
+  }
+
+  const handleSubmit = async (event) => {
+    event.preventDefault()
+    if (!onSavePreferences || !hasChanges) return
+
+    try {
+      setSaving(true)
+      await onSavePreferences(localPreferences)
+      setHasChanges(false)
+    } catch (error) {
+      console.error("Failed to save cash burn preferences", error)
+      alert("We couldn't save your preferences. Please try again.")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="cashburn-section">
+      <header className="cashburn-header">
+        <div>
+          <h2>Weekly Cash Burn</h2>
+          <p className="cashburn-subtitle">
+            Stay ahead of spend by tracking category leaks, pace, and nudges in one view.
+          </p>
+        </div>
+        <div className={`pace-chip pace-chip--${report?.pace?.status || "neutral"}`}>
+          {report?.pace?.status === "overpace" && "🔥 Over pace"}
+          {report?.pace?.status === "underpace" && "🌱 Under pace"}
+          {(!report?.pace?.status || report?.pace?.status === "on_track") && "✅ On track"}
+        </div>
+      </header>
+
+      <div className="cashburn-grid">
+        <article className="cashburn-card">
+          <div className="cashburn-card-header">
+            <h3>Week-to-date burn</h3>
+            <span className="cashburn-period">
+              {report ? `${new Date(report.weekRange.start).toLocaleDateString()} – ${new Date(report.weekRange.end).toLocaleDateString()}` : "No data"}
+            </span>
+          </div>
+          <div className="cashburn-totals">
+            <div>
+              <p className="cashburn-label">Actual</p>
+              <p className="cashburn-value">{formatCurrency(report?.totalBurn || 0)}</p>
+            </div>
+            <div>
+              <p className="cashburn-label">Expected pace</p>
+              <p className="cashburn-value cashburn-value--muted">
+                {formatCurrency(report?.expectedDailyBurn ? report.expectedDailyBurn * report.pace.daysElapsed : 0)}
+              </p>
+            </div>
+            <div>
+              <p className="cashburn-label">Pace delta</p>
+              <p
+                className={`cashburn-value ${
+                  report?.pace?.status === "overpace"
+                    ? "cashburn-value--bad"
+                    : report?.pace?.status === "underpace"
+                    ? "cashburn-value--good"
+                    : ""
+                }`}
+              >
+                {formatPercent((report?.pace?.ratio || 1) - 1, { showSign: true })}
+              </p>
+            </div>
+          </div>
+          <p className="cashburn-message">{report?.pace?.message || "We’ll calculate your pace once transactions start flowing."}</p>
+          <div className="cashburn-history">
+            <HistorySparkline history={history} />
+            <span className="cashburn-history-label">Trailing weeks</span>
+          </div>
+        </article>
+
+        <article className="cashburn-card">
+          <div className="cashburn-card-header">
+            <h3>Top leak categories</h3>
+            <span className="cashburn-label">Prioritized by burn and velocity</span>
+          </div>
+          {leakCategories.length === 0 ? (
+            <p className="cashburn-empty">No major leaks this week. Keep it up!</p>
+          ) : (
+            <ul className="cashburn-category-list">
+              {leakCategories.map((category) => (
+                <li key={category.name} className="cashburn-category-item">
+                  <div>
+                    <p className="cashburn-category-name">{category.name}</p>
+                    <p className="cashburn-category-meta">
+                      {formatCurrency(category.amount)} · {formatPercent(category.share, { decimals: 1 })} of spend
+                    </p>
+                    {Number.isFinite(category.trend) && (
+                      <p className={`cashburn-category-trend ${category.trend > 0 ? "trend-up" : "trend-down"}`}>
+                        {category.trend > 0 ? "▲" : "▼"} vs. last week {formatPercent(Math.abs(category.trend), { decimals: 1 })}
+                      </p>
+                    )}
+                  </div>
+                  <Sparkline data={category.sparkline} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="cashburn-card">
+          <div className="cashburn-card-header">
+            <h3>Real-time nudges</h3>
+            <span className="cashburn-label">Respecting quiet hours and thresholds</span>
+          </div>
+          {activeNudges.length === 0 ? (
+            <p className="cashburn-empty">You’ll see nudges here when spending sprints ahead of plan.</p>
+          ) : (
+            <ul className="cashburn-nudges">
+              {activeNudges.map((nudge) => (
+                <li key={nudge.id} className={`cashburn-nudge cashburn-nudge--${nudge.severity || "info"}`}>
+                  <div>
+                    <p className="cashburn-nudge-message">{nudge.message}</p>
+                    <p className="cashburn-nudge-meta">
+                      {new Date(nudge.created_at || nudge.createdAt || Date.now()).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                      {nudge.category ? ` · ${nudge.category}` : ""}
+                    </p>
+                  </div>
+                  {onDismissNudge && (
+                    <button className="cashburn-nudge-dismiss" type="button" onClick={() => onDismissNudge(nudge.id)}>
+                      Dismiss
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="cashburn-card">
+          <div className="cashburn-card-header">
+            <h3>Scheduling & thresholds</h3>
+            <span className="cashburn-label">Control report cadence and alerts</span>
+          </div>
+          <form className="cashburn-form" onSubmit={handleSubmit}>
+            <label className="cashburn-form-field">
+              <span>Weekly report drop</span>
+              <select
+                value={resolvedPreferences.weeklyReportDay}
+                onChange={(event) => handleFieldChange("weeklyReportDay", event.target.value)}
+              >
+                {DAY_OPTIONS.map((day) => (
+                  <option key={day} value={day}>
+                    {day}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="cashburn-form-field">
+              <span>Report time</span>
+              <input
+                type="time"
+                value={resolvedPreferences.weeklyReportTime}
+                onChange={(event) => handleFieldChange("weeklyReportTime", event.target.value)}
+              />
+            </label>
+
+            <div className="cashburn-form-field cashburn-form-field--inline">
+              <label>
+                <span>Quiet hours start</span>
+                <input
+                  type="time"
+                  value={resolvedPreferences.quietHours?.start}
+                  onChange={(event) => handleQuietHoursChange("start", event.target.value)}
+                />
+              </label>
+              <label>
+                <span>Quiet hours end</span>
+                <input
+                  type="time"
+                  value={resolvedPreferences.quietHours?.end}
+                  onChange={(event) => handleQuietHoursChange("end", event.target.value)}
+                />
+              </label>
+            </div>
+
+            <label className="cashburn-form-field">
+              <span>Alert sensitivity ({Math.round((resolvedPreferences.alertThreshold || 0) * 100)}% pace swing)</span>
+              <input
+                type="range"
+                min="0.05"
+                max="0.5"
+                step="0.05"
+                value={resolvedPreferences.alertThreshold || DEFAULT_CASH_BURN_PREFERENCES.alertThreshold}
+                onChange={(event) => handleFieldChange("alertThreshold", Number(event.target.value))}
+              />
+            </label>
+
+            <label className="cashburn-form-field cashburn-toggle">
+              <input
+                type="checkbox"
+                checked={Boolean(resolvedPreferences.realtimeEnabled)}
+                onChange={(event) => handleFieldChange("realtimeEnabled", event.target.checked)}
+              />
+              <span>Enable paid real-time nudges</span>
+            </label>
+
+            <label className="cashburn-form-field cashburn-toggle">
+              <input
+                type="checkbox"
+                checked={Boolean(resolvedPreferences.showSponsoredSlot)}
+                onChange={(event) => handleFieldChange("showSponsoredSlot", event.target.checked)}
+              />
+              <span>Allow sponsored money-saving tips</span>
+            </label>
+
+            <button className="primary-button" type="submit" disabled={saving || !hasChanges}>
+              {saving ? "Saving..." : hasChanges ? "Save preferences" : "Saved"}
+            </button>
+          </form>
+        </article>
+
+        {!isPaidPlan && resolvedPreferences.showSponsoredSlot && (
+          <aside className="cashburn-sponsored" aria-label="Sponsored">
+            <div className="cashburn-sponsored-badge">Sponsored</div>
+            <h3>Upgrade to Pocket Budget Pro</h3>
+            <p>
+              Lock in real-time AI nudges, automated savings workflows, and 24/7 support for less than the cost of one latte a week.
+            </p>
+            <button type="button" className="secondary-button">
+              Explore Pro plans
+            </button>
+          </aside>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -179,6 +179,552 @@ let demoCategories = {
   ],
 }
 
+export const DEFAULT_CASH_BURN_PREFERENCES = {
+  planTier: "free",
+  weeklyReportDay: "Monday",
+  weeklyReportTime: "09:00",
+  quietHours: { start: "21:00", end: "07:00" },
+  alertThreshold: 0.15,
+  realtimeEnabled: true,
+  pollIntervalMinutes: 15,
+  showSponsoredSlot: true,
+}
+
+let demoCashBurnPreferences = {}
+let demoCashBurnReports = []
+let demoCashBurnAlerts = []
+
+const DEMO_ALERT_EVENT = "demo-cash-burn-alert"
+
+const emitDemoAlertEvent = (payload) => {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new CustomEvent(DEMO_ALERT_EVENT, { detail: payload }))
+  }
+}
+
+const dayNameToIndex = {
+  sunday: 0,
+  monday: 1,
+  tuesday: 2,
+  wednesday: 3,
+  thursday: 4,
+  friday: 5,
+  saturday: 6,
+}
+
+const normalizeQuietHours = (quietHours) => {
+  if (!quietHours) {
+    return { ...DEFAULT_CASH_BURN_PREFERENCES.quietHours }
+  }
+
+  return {
+    start: quietHours.start || DEFAULT_CASH_BURN_PREFERENCES.quietHours.start,
+    end: quietHours.end || DEFAULT_CASH_BURN_PREFERENCES.quietHours.end,
+  }
+}
+
+const toCamelPreferences = (row) => {
+  if (!row) return null
+  return {
+    planTier: row.plan_tier || DEFAULT_CASH_BURN_PREFERENCES.planTier,
+    weeklyReportDay: row.weekly_report_day || DEFAULT_CASH_BURN_PREFERENCES.weeklyReportDay,
+    weeklyReportTime: row.weekly_report_time || DEFAULT_CASH_BURN_PREFERENCES.weeklyReportTime,
+    quietHours: normalizeQuietHours(row.quiet_hours),
+    alertThreshold:
+      typeof row.alert_threshold === "number"
+        ? row.alert_threshold
+        : DEFAULT_CASH_BURN_PREFERENCES.alertThreshold,
+    realtimeEnabled:
+      typeof row.realtime_enabled === "boolean"
+        ? row.realtime_enabled
+        : DEFAULT_CASH_BURN_PREFERENCES.realtimeEnabled,
+    pollIntervalMinutes:
+      typeof row.poll_interval_minutes === "number"
+        ? row.poll_interval_minutes
+        : DEFAULT_CASH_BURN_PREFERENCES.pollIntervalMinutes,
+    showSponsoredSlot:
+      typeof row.show_sponsored_slot === "boolean"
+        ? row.show_sponsored_slot
+        : DEFAULT_CASH_BURN_PREFERENCES.showSponsoredSlot,
+  }
+}
+
+const toSnakePreferences = (userId, preferences) => ({
+  user_id: userId,
+  plan_tier: preferences.planTier,
+  weekly_report_day: preferences.weeklyReportDay,
+  weekly_report_time: preferences.weeklyReportTime,
+  quiet_hours: preferences.quietHours,
+  alert_threshold: preferences.alertThreshold,
+  realtime_enabled: preferences.realtimeEnabled,
+  poll_interval_minutes: preferences.pollIntervalMinutes,
+  show_sponsored_slot: preferences.showSponsoredSlot,
+  updated_at: new Date().toISOString(),
+})
+
+const ensureDemoCashBurnPreferences = (userId) => {
+  if (!demoCashBurnPreferences[userId]) {
+    demoCashBurnPreferences[userId] = { ...DEFAULT_CASH_BURN_PREFERENCES }
+  }
+  return demoCashBurnPreferences[userId]
+}
+
+const calculateWeekRange = (date = new Date(), weekStartsOn = 1) => {
+  const current = new Date(date)
+  current.setHours(0, 0, 0, 0)
+  const day = current.getDay()
+  const normalizedWeekStart = Number.isInteger(weekStartsOn) ? weekStartsOn : 1
+  const diff = (day < normalizedWeekStart ? 7 : 0) + day - normalizedWeekStart
+  const weekStart = new Date(current)
+  weekStart.setDate(current.getDate() - diff)
+  const weekEnd = new Date(weekStart)
+  weekEnd.setDate(weekStart.getDate() + 6)
+  weekEnd.setHours(23, 59, 59, 999)
+  return { weekStart, weekEnd }
+}
+
+const startOfPreviousWeek = (weekStart) => {
+  const previous = new Date(weekStart)
+  previous.setDate(previous.getDate() - 7)
+  previous.setHours(0, 0, 0, 0)
+  return previous
+}
+
+const endOfWeek = (weekStart) => {
+  const end = new Date(weekStart)
+  end.setDate(end.getDate() + 6)
+  end.setHours(23, 59, 59, 999)
+  return end
+}
+
+const toISODate = (date) => {
+  const clone = new Date(date)
+  clone.setHours(0, 0, 0, 0)
+  return clone.toISOString()
+}
+
+const safeNumber = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) ? number : 0
+}
+
+const parseTransactionDate = (value) => {
+  if (!value) return null
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  return parsed
+}
+
+const getWeeklyTransactions = (budgets, start, end) => {
+  const transactions = []
+  budgets.forEach((budget) => {
+    ;(budget.transactions || []).forEach((transaction) => {
+      if (transaction.type !== "expense") return
+      const transactionDate = parseTransactionDate(transaction.date)
+      if (!transactionDate) return
+      if (transactionDate >= start && transactionDate <= end) {
+        transactions.push({
+          ...transaction,
+          amount: Math.abs(safeNumber(transaction.amount)),
+          date: new Date(transactionDate),
+        })
+      }
+    })
+  })
+  return transactions
+}
+
+const buildDailyBurnSeries = (transactions, weekStart) => {
+  const series = new Array(7).fill(0)
+  transactions.forEach((transaction) => {
+    const dayIndex = Math.min(
+      6,
+      Math.max(0, Math.floor((transaction.date - weekStart) / (1000 * 60 * 60 * 24))),
+    )
+    series[dayIndex] += transaction.amount
+  })
+  return series
+}
+
+const buildCategorySummaries = (
+  currentTransactions,
+  previousTransactions,
+  totalBurn,
+  quietHours,
+  alertThreshold,
+  weekStart,
+) => {
+  const map = new Map()
+  const previousMap = new Map()
+
+  previousTransactions.forEach((transaction) => {
+    const key = (transaction.category || "Uncategorized").toLowerCase()
+    const previous = previousMap.get(key) || { amount: 0 }
+    previous.amount += transaction.amount
+    previousMap.set(key, previous)
+  })
+
+  currentTransactions.forEach((transaction) => {
+    const key = (transaction.category || "Uncategorized").toLowerCase()
+    const entry =
+      map.get(key) || {
+        name: transaction.category || "Uncategorized",
+        amount: 0,
+        transactions: 0,
+        dailySeries: new Array(7).fill(0),
+        previousAmount: previousMap.get(key)?.amount || 0,
+      }
+
+    entry.amount += transaction.amount
+    entry.transactions += 1
+    const dayIndex = Math.min(
+      6,
+      Math.max(0, Math.floor((transaction.date - weekStart) / (1000 * 60 * 60 * 24))),
+    )
+    entry.dailySeries[dayIndex] += transaction.amount
+    map.set(key, entry)
+  })
+
+  const categories = Array.from(map.values()).map((entry) => {
+    const share = totalBurn > 0 ? entry.amount / totalBurn : 0
+    const trend = entry.previousAmount > 0 ? (entry.amount - entry.previousAmount) / entry.previousAmount : null
+    const isLeak = share >= 0.2 || (trend !== null && trend > alertThreshold)
+    return {
+      name: entry.name,
+      amount: Number(entry.amount.toFixed(2)),
+      share: Number(share.toFixed(3)),
+      previousAmount: Number(entry.previousAmount.toFixed(2)),
+      trend: trend !== null ? Number(trend.toFixed(3)) : null,
+      isLeak,
+      sparkline: entry.dailySeries,
+      transactions: entry.transactions,
+      quietHoursRespected: Boolean(quietHours),
+    }
+  })
+
+  return categories.sort((a, b) => b.amount - a.amount)
+}
+
+const sumBudgetedAmounts = (budgets) => {
+  let total = 0
+  budgets.forEach((budget) => {
+    ;(budget.categoryBudgets || []).forEach((category) => {
+      total += safeNumber(category.budgetedAmount || category.budgeted_amount)
+    })
+  })
+  return total
+}
+
+const toReportRecord = (uiReport) => ({
+  week_start: uiReport.weekRange.start,
+  week_end: uiReport.weekRange.end,
+  total_burn: uiReport.totalBurn,
+  average_daily_burn: uiReport.averageDailyBurn,
+  expected_daily_burn: uiReport.expectedDailyBurn,
+  pace_status: uiReport.pace.status,
+  pace_ratio: uiReport.pace.ratio,
+  categories: uiReport.categories,
+  daily_burn: uiReport.dailyBurn,
+  leak_categories: uiReport.leakCategories,
+  threshold_breached: uiReport.thresholdBreached,
+  created_at: new Date().toISOString(),
+})
+
+const normalizeReportRecord = (record) => {
+  if (!record) return null
+  return {
+    id: record.id,
+    weekRange: {
+      start: record.week_start,
+      end: record.week_end,
+    },
+    totalBurn: safeNumber(record.total_burn),
+    averageDailyBurn: safeNumber(record.average_daily_burn),
+    expectedDailyBurn: safeNumber(record.expected_daily_burn),
+    pace: {
+      status: record.pace_status,
+      ratio: safeNumber(record.pace_ratio),
+    },
+    categories: Array.isArray(record.categories) ? record.categories : [],
+    dailyBurn: Array.isArray(record.daily_burn) ? record.daily_burn : [],
+    leakCategories: Array.isArray(record.leak_categories) ? record.leak_categories : [],
+    thresholdBreached: Boolean(record.threshold_breached),
+    createdAt: record.created_at,
+  }
+}
+
+export const calculateWeeklyCashBurn = (budgets = [], preferences = DEFAULT_CASH_BURN_PREFERENCES) => {
+  const mergedPreferences = {
+    ...DEFAULT_CASH_BURN_PREFERENCES,
+    ...preferences,
+    quietHours: normalizeQuietHours(preferences?.quietHours),
+  }
+
+  const weekStartsOn =
+    dayNameToIndex[String(mergedPreferences.weeklyReportDay || "Monday").toLowerCase()] ?? 1
+  const { weekStart, weekEnd } = calculateWeekRange(new Date(), weekStartsOn)
+  const previousWeekStart = startOfPreviousWeek(weekStart)
+  const previousWeekEnd = endOfWeek(previousWeekStart)
+
+  const currentTransactions = getWeeklyTransactions(budgets, weekStart, weekEnd)
+  const previousTransactions = getWeeklyTransactions(budgets, previousWeekStart, previousWeekEnd)
+
+  const totalBurn = currentTransactions.reduce((sum, transaction) => sum + transaction.amount, 0)
+  const dailyBurn = buildDailyBurnSeries(currentTransactions, weekStart)
+  const categories = buildCategorySummaries(
+    currentTransactions,
+    previousTransactions,
+    totalBurn,
+    mergedPreferences.quietHours,
+    mergedPreferences.alertThreshold,
+    weekStart,
+  )
+
+  const leakCategories = categories.filter((category) => category.isLeak).slice(0, 3)
+
+  const totalBudgeted = sumBudgetedAmounts(budgets)
+  const now = new Date()
+  const daysElapsed = Math.min(7, Math.max(1, Math.floor((now - weekStart) / (1000 * 60 * 60 * 24)) + 1))
+  const expectedDailyBurn = totalBudgeted > 0 ? totalBudgeted / 7 : 0
+  const expectedToDate = expectedDailyBurn * daysElapsed
+  const paceRatio = expectedToDate > 0 ? totalBurn / expectedToDate : 1
+  let paceStatus = "on_track"
+  if (paceRatio > 1 + mergedPreferences.alertThreshold) {
+    paceStatus = "overpace"
+  } else if (paceRatio < 1 - mergedPreferences.alertThreshold) {
+    paceStatus = "underpace"
+  }
+
+  const paceMessageLookup = {
+    overpace: "Spending is running hotter than planned.",
+    on_track: "You're right on track this week.",
+    underpace: "You're pacing under budget—nice work!",
+  }
+
+  const uiReport = {
+    weekRange: {
+      start: toISODate(weekStart),
+      end: toISODate(weekEnd),
+    },
+    totalBurn: Number(totalBurn.toFixed(2)),
+    averageDailyBurn: Number((totalBurn / 7).toFixed(2)),
+    expectedDailyBurn: Number(expectedDailyBurn.toFixed(2)),
+    pace: {
+      status: paceStatus,
+      ratio: Number(paceRatio.toFixed(3)),
+      message: paceMessageLookup[paceStatus],
+      daysElapsed,
+    },
+    categories: categories.slice(0, 6),
+    leakCategories,
+    dailyBurn,
+    thresholdBreached: paceStatus === "overpace",
+    alertThreshold: mergedPreferences.alertThreshold,
+  }
+
+  const storageRecord = toReportRecord(uiReport)
+
+  return { ui: uiReport, record: storageRecord }
+}
+
+export const getCashBurnPreferences = async (userId) => {
+  if (userId === DEMO_ADMIN.user.id) {
+    const data = ensureDemoCashBurnPreferences(userId)
+    return { data, error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_preferences")
+    .select("*")
+    .eq("user_id", userId)
+    .maybeSingle()
+
+  if (error && error.code !== "PGRST116") {
+    return { data: null, error }
+  }
+
+  const preferences = toCamelPreferences(data) || { ...DEFAULT_CASH_BURN_PREFERENCES }
+  return { data: preferences, error: null }
+}
+
+export const upsertCashBurnPreferences = async (userId, preferences) => {
+  const mergedPreferences = {
+    ...DEFAULT_CASH_BURN_PREFERENCES,
+    ...preferences,
+    quietHours: normalizeQuietHours(preferences?.quietHours),
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    demoCashBurnPreferences[userId] = mergedPreferences
+    return { data: mergedPreferences, error: null }
+  }
+
+  const payload = toSnakePreferences(userId, mergedPreferences)
+  const { data, error } = await supabase
+    .from("cash_burn_preferences")
+    .upsert([payload], { onConflict: "user_id" })
+    .select()
+    .single()
+
+  if (error) {
+    return { data: null, error }
+  }
+
+  return { data: toCamelPreferences(data), error: null }
+}
+
+export const getCashBurnReports = async (userId, { limit = 8 } = {}) => {
+  if (userId === DEMO_ADMIN.user.id) {
+    const sorted = [...demoCashBurnReports].sort((a, b) => (a.week_start < b.week_start ? 1 : -1))
+    return { data: sorted.slice(0, limit).map(normalizeReportRecord), error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_reports")
+    .select("*")
+    .eq("user_id", userId)
+    .order("week_start", { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    return { data: null, error }
+  }
+
+  return { data: data.map(normalizeReportRecord), error: null }
+}
+
+export const upsertCashBurnReport = async (userId, reportRecord) => {
+  if (!reportRecord) {
+    return { data: null, error: { message: "Missing report payload" } }
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    const index = demoCashBurnReports.findIndex((report) => report.week_start === reportRecord.week_start)
+    const normalizedRecord = {
+      ...reportRecord,
+      id: reportRecord.id || `demo-report-${Date.now()}`,
+      user_id: userId,
+    }
+    if (index >= 0) {
+      demoCashBurnReports[index] = { ...demoCashBurnReports[index], ...normalizedRecord }
+    } else {
+      demoCashBurnReports.push(normalizedRecord)
+    }
+    return { data: normalizeReportRecord(normalizedRecord), error: null }
+  }
+
+  const payload = { ...reportRecord, user_id: userId }
+  const { data, error } = await supabase
+    .from("cash_burn_reports")
+    .upsert([payload], { onConflict: "user_id,week_start" })
+    .select()
+    .single()
+
+  if (error) {
+    return { data: null, error }
+  }
+
+  return { data: normalizeReportRecord(data), error: null }
+}
+
+export const getCashBurnAlerts = async (userId, { limit = 20 } = {}) => {
+  if (userId === DEMO_ADMIN.user.id) {
+    const sorted = [...demoCashBurnAlerts].sort((a, b) => (a.created_at < b.created_at ? 1 : -1))
+    return { data: sorted.slice(0, limit), error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("cash_burn_alerts")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(limit)
+
+  return { data, error }
+}
+
+export const logCashBurnAlert = async (userId, alertPayload) => {
+  const payload = {
+    id: alertPayload.id || `alert-${Date.now()}`,
+    user_id: userId,
+    message: alertPayload.message,
+    severity: alertPayload.severity || "info",
+    category: alertPayload.category || null,
+    pace_ratio: alertPayload.paceRatio || null,
+    quiet_hours_respected: alertPayload.quietHoursRespected ?? true,
+    delivery: alertPayload.delivery || "realtime",
+    created_at: alertPayload.createdAt || new Date().toISOString(),
+    week_start: alertPayload.weekStart || null,
+    week_end: alertPayload.weekEnd || null,
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    demoCashBurnAlerts.unshift(payload)
+    emitDemoAlertEvent(payload)
+    return { data: payload, error: null }
+  }
+
+  const { data, error } = await supabase.from("cash_burn_alerts").insert([payload]).select().single()
+
+  if (!error) {
+    emitDemoAlertEvent(data)
+  }
+
+  return { data, error }
+}
+
+export const subscribeToCashBurnAlerts = (userId, callback) => {
+  if (!userId || typeof callback !== "function") {
+    return { unsubscribe: () => {} }
+  }
+
+  if (userId === DEMO_ADMIN.user.id) {
+    const handler = (event) => {
+      if (event.detail?.user_id === userId) {
+        callback(event.detail)
+      }
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener(DEMO_ALERT_EVENT, handler)
+    }
+    return {
+      unsubscribe: () => {
+        if (typeof window !== "undefined") {
+          window.removeEventListener(DEMO_ALERT_EVENT, handler)
+        }
+      },
+    }
+  }
+
+  const channel = supabase
+    .channel(`cash-burn-alerts-${userId}`)
+    .on(
+      "postgres_changes",
+      {
+        event: "INSERT",
+        schema: "public",
+        table: "cash_burn_alerts",
+        filter: `user_id=eq.${userId}`,
+      },
+      (payload) => {
+        if (payload?.new) {
+          callback(payload.new)
+        }
+      },
+    )
+    .subscribe()
+
+  return {
+    unsubscribe: () => {
+      if (channel) {
+        supabase.removeChannel(channel)
+      }
+    },
+  }
+}
+
 export const getBudgets = async (userId) => {
   // For demo admin, return in-memory data
   if (userId === DEMO_ADMIN.user.id) {

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -2,8 +2,21 @@
 
 import { useState } from "react"
 import { createBudget, updateBudget, deleteBudget } from "../lib/supabase"
+import CashBurnDashboard from "../components/CashBurnDashboard"
 
-export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode, setBudgets, userId }) {
+export default function BudgetsScreen({
+  budgets,
+  setSelectedBudget,
+  setViewMode,
+  setBudgets,
+  userId,
+  cashBurnReport,
+  cashBurnHistory,
+  cashBurnPreferences,
+  onSaveCashBurnPreferences,
+  activeNudges,
+  onDismissNudge,
+}) {
   const [editingBudgetId, setEditingBudgetId] = useState(null)
   const [budgetNameInput, setBudgetNameInput] = useState("")
   const [openMenuId, setOpenMenuId] = useState(null)
@@ -128,6 +141,15 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
       <div className="header-section">
         <p className="tagline">Manage your budgets and stay on top of your finances.</p>
       </div>
+
+      <CashBurnDashboard
+        report={cashBurnReport}
+        history={cashBurnHistory}
+        preferences={cashBurnPreferences}
+        onSavePreferences={onSaveCashBurnPreferences}
+        activeNudges={activeNudges}
+        onDismissNudge={onDismissNudge}
+      />
 
       {budgets.length === 0 ? (
         <div className="empty-state">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -2756,3 +2756,333 @@ select.input {
     text-align: center;
   }
 }
+/* Cash burn dashboard */
+.cashburn-section {
+  margin: 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.cashburn-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cashburn-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+}
+
+.cashburn-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: var(--gray-500);
+}
+
+.pace-chip {
+  padding: 0.4rem 0.85rem;
+  border-radius: var(--radius-full);
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: var(--gray-200);
+  color: var(--gray-700);
+  white-space: nowrap;
+}
+
+.pace-chip--overpace {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red-600);
+}
+
+.pace-chip--underpace {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--green-600);
+}
+
+.pace-chip--on_track,
+.pace-chip--neutral {
+  background: var(--gray-200);
+  color: var(--gray-700);
+}
+
+.cashburn-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .cashburn-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.cashburn-card {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cashburn-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.cashburn-card-header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.cashburn-period {
+  font-size: 0.85rem;
+  color: var(--gray-500);
+}
+
+.cashburn-totals {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.cashburn-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--gray-500);
+}
+
+.cashburn-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0.25rem 0 0;
+}
+
+.cashburn-value--muted {
+  color: var(--gray-500);
+}
+
+.cashburn-value--bad {
+  color: var(--red-500);
+}
+
+.cashburn-value--good {
+  color: var(--green-500);
+}
+
+.cashburn-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--gray-600);
+}
+
+.cashburn-history {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cashburn-history-label {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.cashburn-category-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cashburn-category-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.cashburn-category-name {
+  font-weight: 600;
+  margin: 0;
+}
+
+.cashburn-category-meta {
+  margin: 0.15rem 0 0;
+  font-size: 0.85rem;
+  color: var(--gray-500);
+}
+
+.cashburn-category-trend {
+  margin: 0.2rem 0 0;
+  font-size: 0.8rem;
+}
+
+.cashburn-category-trend.trend-up {
+  color: var(--red-500);
+}
+
+.cashburn-category-trend.trend-down {
+  color: var(--green-600);
+}
+
+.cashburn-empty {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--gray-500);
+}
+
+.sparkline {
+  width: 100px;
+  height: 48px;
+}
+
+.sparkline--empty {
+  background: var(--gray-100);
+  border-radius: var(--radius-md);
+  height: 48px;
+  width: 100px;
+}
+
+.sparkline-path {
+  fill: none;
+  stroke: var(--primary-500);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.cashburn-nudges {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-nudge {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-lg);
+  background: var(--gray-100);
+}
+
+.cashburn-nudge--warning {
+  background: rgba(245, 158, 11, 0.15);
+}
+
+.cashburn-nudge--critical {
+  background: rgba(239, 68, 68, 0.18);
+}
+
+.cashburn-nudge-message {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.cashburn-nudge-meta {
+  margin: 0.15rem 0 0;
+  font-size: 0.8rem;
+  color: var(--gray-500);
+}
+
+.cashburn-nudge-dismiss {
+  border: none;
+  background: transparent;
+  color: var(--primary-600);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.cashburn-nudge-dismiss:hover {
+  text-decoration: underline;
+}
+
+.cashburn-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.cashburn-form-field select,
+.cashburn-form-field input[type="time"],
+.cashburn-form-field input[type="range"] {
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--gray-200);
+  font-size: 0.9rem;
+}
+
+.cashburn-form-field input[type="range"] {
+  padding: 0;
+}
+
+.cashburn-form-field--inline {
+  flex-direction: row;
+  gap: 0.75rem;
+}
+
+.cashburn-form-field--inline label {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.cashburn-toggle {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.cashburn-sponsored {
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+  color: white;
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cashburn-sponsored h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.cashburn-sponsored p {
+  margin: 0;
+  font-size: 0.95rem;
+  opacity: 0.9;
+}
+
+.cashburn-sponsored-badge {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.2);
+  font-size: 0.75rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
## Summary
- add Supabase helpers and aggregation utilities for cash-burn reports, preferences, and alerts
- integrate weekly cash-burn calculations, preferences, and paid real-time nudges into the app flow
- build a Cash Burn dashboard with scheduling controls, leak visuals, and styling inside the Budgets screen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc58a8bc832ebbe7ad462dcdfc1e