### PR TITLE
Add confirmation modal for category deletions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -155,6 +155,7 @@ function AppContent() {
           categories={categories}
           setCategories={handleCategoriesUpdate}
           budgets={budgets}
+          setBudgets={setBudgets}
           setViewMode={setViewMode}
         />
       )}


### PR DESCRIPTION
## Summary
- prompt users with a confirmation modal before deleting categories and explain the need to reassign remaining funds
- collect reallocation selections for category budget amounts and persist the updated allocations through Supabase
- update local budget state when reallocating so budget totals stay accurate after a deletion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc5ac7e4832eaafddb19f11daf00