### PR TITLE
Add sponsored ad slots with analytics tracking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import Header from "./components/Header"
 import InstallPrompt from "./components/InstallPrompt"
 
 function AppContent() {
-  const { user, loading: authLoading, initializing } = useAuth()
+  const { user, userProfile, loading: authLoading, initializing } = useAuth()
   const [budgets, setBudgets] = useState([])
   const [categories, setCategories] = useState({
     income: [
@@ -125,6 +125,10 @@ function AppContent() {
     return <LoadingScreen message="Setting up your account" />
   }
 
+  const adsEnabled = userProfile?.ads_enabled ?? true
+  const subscriptionTier = userProfile?.subscription_tier ?? "free"
+  const isPaidSubscriber = subscriptionTier !== "free"
+
   return (
     <div className="container">
       <Header title="Pocket Budget" showLogout={viewMode === "budgets"} />
@@ -137,6 +141,8 @@ function AppContent() {
           setViewMode={setViewMode}
           setBudgets={setBudgets}
           userId={user.id}
+          adsEnabled={adsEnabled}
+          isPaidSubscriber={isPaidSubscriber}
         />
       )}
       {viewMode === "details" && selectedBudget && (
@@ -148,6 +154,8 @@ function AppContent() {
           budgets={budgets}
           setSelectedBudget={setSelectedBudget}
           userId={user.id}
+          adsEnabled={adsEnabled}
+          isPaidSubscriber={isPaidSubscriber}
         />
       )}
       {viewMode === "categories" && (
@@ -156,9 +164,20 @@ function AppContent() {
           setCategories={handleCategoriesUpdate}
           budgets={budgets}
           setViewMode={setViewMode}
+          adsEnabled={adsEnabled}
+          isPaidSubscriber={isPaidSubscriber}
+          userId={user.id}
         />
       )}
-      {viewMode === "ai" && selectedBudget && <AIInsightsScreen budget={selectedBudget} setViewMode={setViewMode} />}
+      {viewMode === "ai" && selectedBudget && (
+        <AIInsightsScreen
+          budget={selectedBudget}
+          setViewMode={setViewMode}
+          adsEnabled={adsEnabled}
+          isPaidSubscriber={isPaidSubscriber}
+          userId={user.id}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/SponsoredCard.jsx
+++ b/src/components/SponsoredCard.jsx
@@ -1,0 +1,206 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import {
+  fetchSponsoredCreative,
+  recordAdClick,
+  recordAdImpression,
+} from "../lib/supabase"
+
+const MOCK_CREATIVES = [
+  {
+    id: "mock-cashback",
+    title: "Earn 3% Cashback",
+    description: "Open a NovaCard account and get 3% back on groceries this month.",
+    cta: "Learn more",
+    url: "https://example.com/novacard",
+    advertiser: "NovaCard",
+    image: "https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=900&q=80",
+  },
+  {
+    id: "mock-savings",
+    title: "Boost Your Savings",
+    description: "Move spare change into a 4.5% APY vault automatically with Sprout.",
+    cta: "Start saving",
+    url: "https://example.com/sprout",
+    advertiser: "Sprout Savings",
+    image: "https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=900&q=80",
+  },
+  {
+    id: "mock-budget",
+    title: "Tackle Debt Faster",
+    description: "Consolidate balances into one low-interest payment with Clarity.",
+    cta: "Check your rate",
+    url: "https://example.com/clarity",
+    advertiser: "Clarity Finance",
+    image: "https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=900&q=80",
+  },
+]
+
+const getFallbackCreative = () => {
+  const index = Math.floor(Math.random() * MOCK_CREATIVES.length)
+  return MOCK_CREATIVES[index]
+}
+
+export default function SponsoredCard({
+  placement = "global",
+  userId,
+  adsEnabled = true,
+  isPaid = false,
+  className = "",
+}) {
+  const [creative, setCreative] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [hasRecordedImpression, setHasRecordedImpression] = useState(false)
+  const cardRef = useRef(null)
+
+  const fallbackCreative = useMemo(() => getFallbackCreative(), [])
+
+  useEffect(() => {
+    setHasRecordedImpression(false)
+  }, [creative?.id])
+
+  useEffect(() => {
+    let isMounted = true
+
+    if (!adsEnabled || isPaid) {
+      setCreative(null)
+      setLoading(false)
+      setError(null)
+      return () => {
+        isMounted = false
+      }
+    }
+
+    const loadCreative = async () => {
+      setLoading(true)
+      setError(null)
+
+      try {
+        const { data } = await fetchSponsoredCreative(placement)
+        if (!isMounted) return
+        setCreative(data ?? fallbackCreative)
+      } catch (err) {
+        if (!isMounted) return
+        console.error(err)
+        setCreative(fallbackCreative)
+        setError(err)
+      } finally {
+        if (isMounted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    loadCreative()
+
+    return () => {
+      isMounted = false
+    }
+  }, [adsEnabled, fallbackCreative, isPaid, placement])
+
+  useEffect(() => {
+    if (!creative || !adsEnabled || isPaid || hasRecordedImpression) return
+
+    const element = cardRef.current
+    if (!element) return
+
+    if (typeof IntersectionObserver === "undefined") {
+      recordAdImpression({
+        creativeId: creative.id,
+        placement,
+        userId,
+      })
+        .catch((err) => console.error("Error recording ad impression:", err))
+        .finally(() => setHasRecordedImpression(true))
+      return
+    }
+
+    const observer = new IntersectionObserver(
+      (entries, obs) => {
+        entries.forEach(async (entry) => {
+          if (entry.isIntersecting) {
+            await recordAdImpression({
+              creativeId: creative.id,
+              placement,
+              userId,
+            })
+            setHasRecordedImpression(true)
+            obs.disconnect()
+          }
+        })
+      },
+      { threshold: 0.5 },
+    )
+
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [adsEnabled, creative, hasRecordedImpression, isPaid, placement, userId])
+
+  const handleClick = async () => {
+    if (!creative || !creative.url) return
+    await recordAdClick({
+      creativeId: creative.id,
+      placement,
+      userId,
+    })
+    window.open(creative.url, "_blank", "noopener,noreferrer")
+  }
+
+  if (isPaid) {
+    return (
+      <div ref={cardRef} className={`sponsored-card ad-free ${className}`}>
+        <div className="sponsored-card__content">
+          <span className="sponsored-card__badge">Ad-free</span>
+          <h3 className="sponsored-card__title">Thanks for supporting Pocket Budget Pro!</h3>
+          <p className="sponsored-card__description">
+            Enjoy an uninterrupted experience and exclusive insights as a paid subscriber.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!adsEnabled) {
+    return null
+  }
+
+  return (
+    <div ref={cardRef} className={`sponsored-card ${className}`}>
+      {loading && (
+        <div className="sponsored-card__skeleton" aria-hidden="true">
+          <div className="sponsored-card__image" />
+          <div className="sponsored-card__text" />
+        </div>
+      )}
+
+      {!loading && creative && (
+        <button type="button" className="sponsored-card__content" onClick={handleClick}>
+          {creative.image && (
+            <div className="sponsored-card__image" style={{ backgroundImage: `url(${creative.image})` }} />
+          )}
+          <div className="sponsored-card__body">
+            <span className="sponsored-card__badge">Sponsored</span>
+            <h3 className="sponsored-card__title">{creative.title}</h3>
+            <p className="sponsored-card__description">{creative.description}</p>
+            <span className="sponsored-card__cta">{creative.cta}</span>
+          </div>
+        </button>
+      )}
+
+      {!loading && !creative && !error && (
+        <div className="sponsored-card__fallback">
+          <span className="sponsored-card__badge">Sponsored</span>
+          <p className="sponsored-card__description">New offers are on their way. Check back soon!</p>
+        </div>
+      )}
+
+      {error && !creative && (
+        <div className="sponsored-card__fallback" role="status">
+          <span className="sponsored-card__badge">Sponsored</span>
+          <p className="sponsored-card__description">We had trouble loading this ad. Please try again later.</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/screens/AIInsightsScreen.jsx
+++ b/src/screens/AIInsightsScreen.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react"
+import SponsoredCard from "../components/SponsoredCard"
 
-export default function AIInsightsScreen({ budget, setViewMode }) {
+export default function AIInsightsScreen({ budget, setViewMode, adsEnabled, isPaidSubscriber, userId }) {
   const [insights, setInsights] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -301,6 +302,14 @@ export default function AIInsightsScreen({ budget, setViewMode }) {
           ← Back to Details
         </button>
         <h1 className="header">AI Financial Report</h1>
+        <div className="ad-slot">
+          <SponsoredCard
+            placement="ai_insights_loading"
+            userId={userId}
+            adsEnabled={adsEnabled}
+            isPaid={isPaidSubscriber}
+          />
+        </div>
         <div className="ai-loading">
           <div className="loading-spinner"></div>
           <p>Analyzing your financial data...</p>
@@ -317,6 +326,14 @@ export default function AIInsightsScreen({ budget, setViewMode }) {
           ← Back to Details
         </button>
         <h1 className="header">AI Financial Report</h1>
+        <div className="ad-slot">
+          <SponsoredCard
+            placement="ai_insights_error"
+            userId={userId}
+            adsEnabled={adsEnabled}
+            isPaid={isPaidSubscriber}
+          />
+        </div>
         <div className="error-state">
           <p className="error-message">{error}</p>
           <button className="primary-button" onClick={generateAIInsights}>
@@ -333,6 +350,14 @@ export default function AIInsightsScreen({ budget, setViewMode }) {
         ← Back to Details
       </button>
       <h1 className="header">AI Financial Report</h1>
+      <div className="ad-slot">
+        <SponsoredCard
+          placement="ai_insights"
+          userId={userId}
+          adsEnabled={adsEnabled}
+          isPaid={isPaidSubscriber}
+        />
+      </div>
 
       {/* Compact Health Score */}
       <div className="compact-health-score">

--- a/src/screens/BudgetDetailsScreen.jsx
+++ b/src/screens/BudgetDetailsScreen.jsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import SponsoredCard from "../components/SponsoredCard"
 import { createTransaction, updateTransaction, updateBudget } from "../lib/supabase"
 
 export default function BudgetDetailsScreen({
@@ -11,6 +12,8 @@ export default function BudgetDetailsScreen({
   budgets,
   setSelectedBudget,
   userId,
+  adsEnabled,
+  isPaidSubscriber,
 }) {
   const [tab, setTab] = useState("expenses")
   const [showModal, setShowModal] = useState(false)
@@ -303,6 +306,15 @@ export default function BudgetDetailsScreen({
         <button className="ai-insights-button primary-button" onClick={() => setViewMode("ai")}>
           🧠 AI Finance Report
         </button>
+      </div>
+
+      <div className="ad-slot">
+        <SponsoredCard
+          placement="budget_details"
+          userId={userId}
+          adsEnabled={adsEnabled}
+          isPaid={isPaidSubscriber}
+        />
       </div>
 
       <input

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -1,9 +1,18 @@
 "use client"
 
 import { useState } from "react"
+import SponsoredCard from "../components/SponsoredCard"
 import { createBudget, updateBudget, deleteBudget } from "../lib/supabase"
 
-export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode, setBudgets, userId }) {
+export default function BudgetsScreen({
+  budgets,
+  setSelectedBudget,
+  setViewMode,
+  setBudgets,
+  userId,
+  adsEnabled,
+  isPaidSubscriber,
+}) {
   const [editingBudgetId, setEditingBudgetId] = useState(null)
   const [budgetNameInput, setBudgetNameInput] = useState("")
   const [openMenuId, setOpenMenuId] = useState(null)
@@ -127,6 +136,15 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
     <div>
       <div className="header-section">
         <p className="tagline">Manage your budgets and stay on top of your finances.</p>
+      </div>
+
+      <div className="ad-slot">
+        <SponsoredCard
+          placement="budgets_screen"
+          userId={userId}
+          adsEnabled={adsEnabled}
+          isPaid={isPaidSubscriber}
+        />
       </div>
 
       {budgets.length === 0 ? (

--- a/src/screens/CategoriesScreen.jsx
+++ b/src/screens/CategoriesScreen.jsx
@@ -1,6 +1,15 @@
 import { useState } from "react"
+import SponsoredCard from "../components/SponsoredCard"
 
-export default function CategoriesScreen({ categories, setCategories, budgets, setViewMode }) {
+export default function CategoriesScreen({
+  categories,
+  setCategories,
+  budgets,
+  setViewMode,
+  adsEnabled,
+  isPaidSubscriber,
+  userId,
+}) {
   const [tab, setTab] = useState("expense")
   const [showAddModal, setShowAddModal] = useState(false)
   const [newCat, setNewCat] = useState({ name: "", icon: "💲" })
@@ -92,6 +101,15 @@ export default function CategoriesScreen({ categories, setCategories, budgets, s
         ← Back to Budgets
       </button>
       <h1 className="header">Manage Categories</h1>
+
+      <div className="ad-slot">
+        <SponsoredCard
+          placement="categories_screen"
+          userId={userId}
+          adsEnabled={adsEnabled}
+          isPaid={isPaidSubscriber}
+        />
+      </div>
 
       {/* Tabs */}
       <div className="tabRow">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1756,6 +1756,143 @@ body {
   border: 1px solid var(--gray-200);
 }
 
+.ad-slot {
+  margin: 1.5rem 0;
+}
+
+.sponsored-card {
+  position: relative;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--gray-200);
+  background: linear-gradient(135deg, #ffffff, var(--gray-50));
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  min-height: 160px;
+  display: flex;
+  align-items: stretch;
+}
+
+.sponsored-card.ad-free {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.1), rgba(124, 58, 237, 0.08));
+  border: 1px solid rgba(14, 165, 233, 0.25);
+}
+
+.sponsored-card__content {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  width: 100%;
+  padding: 1.5rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.sponsored-card__content:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 4px;
+}
+
+.sponsored-card__image {
+  width: 120px;
+  min-width: 120px;
+  height: 120px;
+  border-radius: var(--radius-lg);
+  background-size: cover;
+  background-position: center;
+  background-color: var(--gray-200);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.6);
+}
+
+.sponsored-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.sponsored-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: rgba(14, 165, 233, 0.15);
+  color: var(--primary-700);
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius-full);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.sponsored-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--gray-900);
+  font-weight: 700;
+}
+
+.sponsored-card__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--gray-600);
+  line-height: 1.4;
+}
+
+.sponsored-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: var(--primary-600);
+}
+
+.sponsored-card__content:hover .sponsored-card__cta {
+  text-decoration: underline;
+}
+
+.sponsored-card__skeleton {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  width: 100%;
+  padding: 1.5rem;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+.sponsored-card__skeleton .sponsored-card__image {
+  background: var(--gray-200);
+}
+
+.sponsored-card__text {
+  flex: 1;
+  height: 16px;
+  border-radius: var(--radius-full);
+  background: var(--gray-200);
+}
+
+.sponsored-card__fallback {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sponsored-card__fallback .sponsored-card__description {
+  font-size: 0.9rem;
+}
+
+.sponsored-card.ad-free .sponsored-card__title {
+  color: var(--primary-700);
+}
+
+.sponsored-card.ad-free .sponsored-card__description {
+  color: var(--gray-600);
+}
+
 .overBudget {
   color: var(--red-500);
   font-weight: 600;


### PR DESCRIPTION
## Summary
- add a reusable `SponsoredCard` component that loads Supabase creatives or mock fallbacks and records analytics
- surface the ad slot on budgets, details, categories, and AI insights screens while honoring paid/ads-disabled users
- extend Supabase helpers and styling to support ad profile flags, RPC logging, and consistent card presentation

## Testing
- npm run lint *(fails: ESLint configuration file missing in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cc593e88832e8ff92bd7d1370d4c