### PR TITLE
Add allocation defaults and editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react"
 import { AuthProvider, useAuth } from "./contexts/AuthContext"
 import { getBudgets, getUserCategories, updateUserCategories } from "./lib/supabase"
+import { ensureCategoryBudgetShape } from "./utils/budgetAllocations"
 import BudgetsScreen from "./screens/BudgetsScreen"
 import BudgetDetailsScreen from "./screens/BudgetDetailsScreen"
 import CategoriesScreen from "./screens/CategoriesScreen"
@@ -58,7 +59,7 @@ function AppContent() {
             id: budget.id,
             name: budget.name,
             createdAt: new Date(budget.created_at).toLocaleDateString(),
-            categoryBudgets: budget.category_budgets || [],
+            categoryBudgets: ensureCategoryBudgetShape(budget.category_budgets || []),
             transactions:
               budget.transactions?.map((tx) => ({
                 id: tx.id,
@@ -137,6 +138,7 @@ function AppContent() {
           setViewMode={setViewMode}
           setBudgets={setBudgets}
           userId={user.id}
+          categories={categories}
         />
       )}
       {viewMode === "details" && selectedBudget && (

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -676,6 +676,228 @@ body {
   color: var(--red-600);
 }
 
+/* Allocation Editor */
+.allocation-editor {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.allocation-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.allocation-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--gray-900);
+  margin: 0;
+}
+
+.allocation-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.allocation-status {
+  font-size: 0.875rem;
+  color: var(--gray-500);
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--primary-600);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.875rem;
+  text-decoration: underline;
+}
+
+.link-button:hover {
+  color: var(--primary-700);
+}
+
+.allocation-subtitle {
+  margin: 0.5rem 0 1.25rem;
+  font-size: 0.9rem;
+  color: var(--gray-600);
+  line-height: 1.5;
+}
+
+.allocation-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.allocation-empty {
+  padding: 1rem;
+  background: var(--gray-50);
+  border: 1px dashed var(--gray-300);
+  border-radius: var(--radius-lg);
+  text-align: center;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+.allocation-row {
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: 0.75rem;
+  background: var(--gray-50);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.allocation-row-main {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.allocation-input {
+  flex: 1;
+}
+
+.allocation-amount-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.allocation-currency {
+  font-weight: 600;
+  color: var(--gray-500);
+}
+
+.allocation-amount-input {
+  width: 6.5rem;
+  text-align: right;
+}
+
+.allocation-row-meta {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+.allocation-add-button {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.change-log {
+  margin-top: 1.5rem;
+  background: var(--gray-50);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--gray-200);
+  padding: 1rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.change-log h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.change-log-empty {
+  margin: 0;
+  font-size: 0.875rem;
+  color: var(--gray-600);
+}
+
+.change-log-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.change-log-item {
+  border-bottom: 1px solid var(--gray-200);
+  padding-bottom: 0.75rem;
+}
+
+.change-log-item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.change-log-item-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.change-log-description {
+  font-weight: 600;
+  color: var(--gray-900);
+}
+
+.change-log-timestamp {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+.change-log-details {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+  color: var(--gray-600);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.snackbar {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--gray-900);
+  color: white;
+  padding: 0.75rem 1.25rem;
+  border-radius: var(--radius-full);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  z-index: 1100;
+}
+
+.snackbar-message {
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.snackbar-action {
+  background: none;
+  border: none;
+  color: var(--primary-100);
+  font-weight: 600;
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.snackbar-action:hover {
+  text-decoration: underline;
+}
+
 /* Budget Overview Card */
 .budget-overview-card {
   background: white;

--- a/src/utils/budgetAllocations.js
+++ b/src/utils/budgetAllocations.js
@@ -1,0 +1,99 @@
+export const DEFAULT_ALLOCATION_NAMES = [
+  "Housing",
+  "Groceries",
+  "Transportation",
+  "Utilities",
+  "Insurance",
+  "Healthcare",
+  "Savings",
+  "Entertainment",
+]
+
+const randomSegment = () => Math.random().toString(36).slice(2, 10)
+
+export const createClientId = (prefix = "id") => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return `${prefix}-${crypto.randomUUID()}`
+  }
+  return `${prefix}-${Date.now()}-${randomSegment()}`
+}
+
+export const normalizeAmount = (value) => {
+  if (value === null || value === undefined || value === "") {
+    return 0
+  }
+  const parsed = Number.parseFloat(value)
+  return Number.isFinite(parsed) ? Number(parsed) : 0
+}
+
+export const ensureCategoryBudgetShape = (budgets = []) =>
+  budgets.map((item) => ({
+    id: item.id || createClientId("alloc"),
+    category: item.category || "",
+    budgetedAmount: normalizeAmount(item.budgetedAmount),
+    lastUpdated: item.lastUpdated || null,
+  }))
+
+export const buildDefaultCategoryBudgets = (expenseCategories = []) => {
+  const timestamp = new Date().toISOString()
+  const seen = new Set()
+  const defaults = []
+
+  DEFAULT_ALLOCATION_NAMES.forEach((name) => {
+    const trimmed = name.trim()
+    if (!seen.has(trimmed) && trimmed) {
+      seen.add(trimmed)
+      defaults.push({
+        id: createClientId("alloc"),
+        category: trimmed,
+        budgetedAmount: 0,
+        lastUpdated: timestamp,
+      })
+    }
+  })
+
+  expenseCategories
+    .filter(Boolean)
+    .forEach((item) => {
+      const name = typeof item === "string" ? item : item.name
+      const trimmed = (name || "").trim()
+      if (trimmed && !seen.has(trimmed)) {
+        seen.add(trimmed)
+        defaults.push({
+          id: createClientId("alloc"),
+          category: trimmed,
+          budgetedAmount: 0,
+          lastUpdated: timestamp,
+        })
+      }
+    })
+
+  return defaults
+}
+
+export const haveCategoryBudgetsChanged = (nextBudgets = [], prevBudgets = []) => {
+  if (nextBudgets.length !== prevBudgets.length) {
+    return true
+  }
+
+  const prevMap = new Map(prevBudgets.map((item) => [item.id, item]))
+
+  for (const item of nextBudgets) {
+    const previous = prevMap.get(item.id)
+    if (!previous) {
+      return true
+    }
+
+    const prevCategory = (previous.category || "").trim()
+    const nextCategory = (item.category || "").trim()
+    if (prevCategory !== nextCategory) {
+      return true
+    }
+
+    if (normalizeAmount(previous.budgetedAmount) !== normalizeAmount(item.budgetedAmount)) {
+      return true
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary
- seed new budgets with default allocation categories and normalize stored category budgets
- add an allocation editor with undoable updates, change logging, and Supabase synchronization in the budget details view
- style the allocation editor, change log, and snackbar components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc5c7b20832e942a0ae686c43e6f