### PR TITLE
Add cadence-aware budget pacing guardrails

### DIFF
--- a/src/lib/pacing.js
+++ b/src/lib/pacing.js
@@ -1,0 +1,239 @@
+const MS_IN_DAY = 1000 * 60 * 60 * 24
+const EPSILON = 0.01
+
+const GUARDRAIL_LABELS = {
+  green: "On Track",
+  yellow: "Monitor",
+  red: "Over Budget",
+}
+
+const normalizeGuardKey = (key) => (GUARDRAIL_LABELS[key] ? key : "green")
+
+const coerceNumber = (value) => {
+  if (value === undefined || value === null) return null
+  const num = Number(value)
+  return Number.isFinite(num) ? num : null
+}
+
+const parseDate = (value) => {
+  if (!value) return null
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : new Date(value.getTime())
+  }
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const daysInMonth = (year, monthIndex) => new Date(year, monthIndex + 1, 0).getDate()
+
+const addMonths = (date, count) => {
+  const result = new Date(date.getTime())
+  const desiredDay = result.getDate()
+  result.setDate(1)
+  result.setMonth(result.getMonth() + count)
+  const maxDay = daysInMonth(result.getFullYear(), result.getMonth())
+  result.setDate(Math.min(desiredDay, maxDay))
+  return result
+}
+
+const addDays = (date, days) => {
+  const result = new Date(date.getTime())
+  result.setDate(result.getDate() + days)
+  return result
+}
+
+const resolveCadenceSettings = (budget = {}) => {
+  const metadataCandidate =
+    budget.cadenceMetadata ||
+    budget.cadence_settings ||
+    budget.cadenceSettings ||
+    budget.metadata?.cadence ||
+    budget.cadence
+
+  const cadence = typeof metadataCandidate === "string" ? { type: metadataCandidate } : metadataCandidate || {}
+
+  const type = (cadence.type || cadence.interval || cadence.name || "monthly").toString().toLowerCase()
+
+  const startDate =
+    parseDate(cadence.startDate || cadence.start || cadence.anchorDate || budget.cadenceStart || budget.createdAt || budget.created_at) ||
+    new Date()
+
+  const customDays =
+    coerceNumber(cadence.customDays) ??
+    coerceNumber(cadence.days) ??
+    coerceNumber(cadence.length) ??
+    coerceNumber(cadence.daysPerCycle) ??
+    coerceNumber(cadence.intervalDays) ??
+    coerceNumber(cadence.periodDays) ??
+    coerceNumber(cadence.paycheckFrequencyDays) ??
+    coerceNumber(budget.cadenceDays) ??
+    null
+
+  return { type, startDate, customDays }
+}
+
+const resolveCycleLengthInDays = (type, customDays) => {
+  switch (type) {
+    case "weekly":
+      return 7
+    case "biweekly":
+    case "bi-weekly":
+    case "fortnightly":
+      return 14
+    case "semi-monthly":
+    case "semimonthly":
+      return 15
+    case "quarterly":
+      return 91
+    case "yearly":
+    case "annually":
+      return 365
+    case "per-paycheck":
+    case "custom":
+      return Math.max(1, customDays || 14)
+    default:
+      return Math.max(1, customDays || 30)
+  }
+}
+
+const advanceCycle = (date, cadence, direction) => {
+  if (cadence.type === "monthly") {
+    return addMonths(date, direction)
+  }
+
+  const days = resolveCycleLengthInDays(cadence.type, cadence.customDays)
+  return addDays(date, days * direction)
+}
+
+const getCycleWindow = (budget, referenceDate = new Date()) => {
+  const cadence = resolveCadenceSettings(budget)
+  const reference = parseDate(referenceDate) || new Date()
+  reference.setHours(0, 0, 0, 0)
+
+  let cycleStart = parseDate(cadence.startDate) || new Date(reference.getTime())
+  cycleStart.setHours(0, 0, 0, 0)
+
+  const maxIterations = 730 // roughly two years of cycles in either direction
+  let iterations = 0
+
+  // Move backwards until the start is <= reference
+  while (cycleStart.getTime() > reference.getTime() && iterations < maxIterations) {
+    cycleStart = advanceCycle(cycleStart, cadence, -1)
+    iterations += 1
+  }
+
+  let cycleEnd = advanceCycle(cycleStart, cadence, 1)
+
+  while (reference.getTime() >= cycleEnd.getTime() && iterations < maxIterations) {
+    cycleStart = cycleEnd
+    cycleEnd = advanceCycle(cycleStart, cadence, 1)
+    iterations += 1
+  }
+
+  if (iterations >= maxIterations) {
+    const today = new Date(reference.getTime())
+    const tomorrow = addDays(today, 1)
+    return {
+      start: today,
+      end: tomorrow,
+      cycleLengthDays: 1,
+      elapsedDays: 1,
+      elapsedRatio: 1,
+    }
+  }
+
+  const cycleLengthMs = Math.max(cycleEnd.getTime() - cycleStart.getTime(), MS_IN_DAY)
+  const elapsedMs = Math.min(reference.getTime(), cycleEnd.getTime()) - cycleStart.getTime()
+  const cycleLengthDays = cycleLengthMs / MS_IN_DAY
+  const elapsedDays = Math.max(0, elapsedMs) / MS_IN_DAY
+  const elapsedRatio = Math.min(1, Math.max(0, cycleLengthDays > 0 ? elapsedDays / cycleLengthDays : 1))
+
+  return {
+    start: cycleStart,
+    end: cycleEnd,
+    cycleLengthDays,
+    elapsedDays,
+    elapsedRatio,
+  }
+}
+
+const determineStatus = (actual, expected, budgeted) => {
+  if (!budgeted || budgeted <= 0) {
+    return actual > EPSILON ? "red" : "green"
+  }
+
+  if (actual <= expected + EPSILON) {
+    return "green"
+  }
+
+  if (actual <= budgeted + EPSILON) {
+    return "yellow"
+  }
+
+  return "red"
+}
+
+const getBudgetPacing = (budget = {}, referenceDate = new Date()) => {
+  const cycleWindow = getCycleWindow(budget, referenceDate)
+  const { elapsedRatio, start, end } = cycleWindow
+  const transactions = Array.isArray(budget.transactions) ? budget.transactions : []
+  const categoryBudgets = Array.isArray(budget.categoryBudgets) ? budget.categoryBudgets : []
+
+  const startTime = start.getTime()
+  const endTime = end.getTime()
+
+  const inCycleTransactions = transactions.filter((tx) => {
+    if (tx.type !== "expense") return false
+    if (!tx.date) return true
+    const txDate = parseDate(tx.date)
+    if (!txDate) return true
+    const txTime = txDate.getTime()
+    return txTime >= startTime && txTime < endTime
+  })
+
+  const categoryMap = {}
+  let totalActual = 0
+  let totalBudgeted = 0
+
+  categoryBudgets.forEach((categoryConfig) => {
+    const categoryName = categoryConfig?.category || "Uncategorized"
+    const budgetedAmount = Number(categoryConfig?.budgetedAmount) || 0
+    const normalizedName = categoryName.toLowerCase().trim()
+
+    const actual = inCycleTransactions
+      .filter((tx) => (tx.category || "").toLowerCase().trim() === normalizedName)
+      .reduce((sum, tx) => sum + (Number(tx.amount) || 0), 0)
+
+    const expected = budgetedAmount * elapsedRatio
+    const status = determineStatus(actual, expected, budgetedAmount)
+
+    categoryMap[categoryName] = {
+      status,
+      actual,
+      expected,
+      budgeted: budgetedAmount,
+      elapsedRatio,
+    }
+
+    totalActual += actual
+    totalBudgeted += budgetedAmount
+  })
+
+  const expectedTotal = totalBudgeted * elapsedRatio
+  const overallStatus = determineStatus(totalActual, expectedTotal, totalBudgeted)
+
+  return {
+    overall: {
+      status: overallStatus,
+      actual: totalActual,
+      expected: expectedTotal,
+      budgeted: totalBudgeted,
+      elapsedRatio,
+      cycleStart: start,
+      cycleEnd: end,
+    },
+    categories: categoryMap,
+  }
+}
+
+export { getBudgetPacing, GUARDRAIL_LABELS, normalizeGuardKey }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -12,8 +12,14 @@
   --purple-600: #7c3aed;
   --purple-700: #6d28d9;
 
+  --green-50: #ecfdf5;
   --green-500: #10b981;
   --green-600: #059669;
+  --yellow-50: #fefce8;
+  --yellow-400: #facc15;
+  --yellow-500: #eab308;
+  --yellow-600: #ca8a04;
+  --red-50: #fef2f2;
   --red-500: #ef4444;
   --red-600: #dc2626;
 
@@ -686,12 +692,19 @@ body {
   box-shadow: var(--shadow-sm);
 }
 
+.overview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
 .overview-title {
   font-size: 1.25rem;
   font-weight: 700;
   color: var(--gray-900);
-  margin-bottom: 1rem;
-  text-align: center;
+  margin: 0;
 }
 
 .overview-content {
@@ -947,6 +960,93 @@ body {
   height: 100%;
   background: var(--red-500);
   transition: width 0.8s ease-out;
+}
+
+.category-guardrail-section {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.category-guardrail-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.category-guardrail-row {
+  background: var(--gray-50);
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.category-guardrail-row-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.category-guardrail-name {
+  font-weight: 600;
+  color: var(--gray-900);
+  font-size: 1rem;
+}
+
+.category-guardrail-status {
+  font-weight: 600;
+  font-size: 0.875rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.category-guardrail-status--green {
+  color: var(--green-600);
+}
+
+.category-guardrail-status--yellow {
+  color: var(--yellow-600);
+}
+
+.category-guardrail-status--red {
+  color: var(--red-600);
+}
+
+.category-guardrail-figures {
+  display: flex;
+  align-items: baseline;
+  gap: 0.35rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--gray-700);
+}
+
+.category-guardrail-actual {
+  color: var(--gray-900);
+}
+
+.category-guardrail-divider {
+  color: var(--gray-400);
+}
+
+.category-guardrail-budget {
+  color: var(--gray-500);
+  font-weight: 500;
+}
+
+.category-guardrail-expected {
+  font-size: 0.8rem;
+  color: var(--gray-500);
 }
 
 /* Transactions Section */
@@ -1249,6 +1349,62 @@ body {
 .budgetCard-info {
   flex: 1;
   cursor: pointer;
+}
+
+.budget-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.guard-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  border-radius: var(--radius-full);
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.guard-pill--green {
+  background: var(--green-50);
+  color: var(--green-600);
+  border-color: rgba(16, 185, 129, 0.3);
+}
+
+.guard-pill--yellow {
+  background: var(--yellow-50);
+  color: var(--yellow-600);
+  border-color: rgba(234, 179, 8, 0.35);
+}
+
+.guard-pill--red {
+  background: var(--red-50);
+  color: var(--red-600);
+  border-color: rgba(239, 68, 68, 0.35);
+}
+
+.guard-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: var(--radius-full);
+}
+
+.guard-dot--green {
+  background: var(--green-500);
+}
+
+.guard-dot--yellow {
+  background: var(--yellow-500);
+}
+
+.guard-dot--red {
+  background: var(--red-500);
 }
 
 .budgetName {
@@ -1817,9 +1973,38 @@ body {
   margin-bottom: 1rem;
 }
 
+.category-budget-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
 .category-budget-name {
   font-weight: 600;
   margin-bottom: 0.25rem;
+}
+
+.category-budget-status {
+  font-size: 0.75rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.category-budget-status--green {
+  color: var(--green-600);
+}
+
+.category-budget-status--yellow {
+  color: var(--yellow-600);
+}
+
+.category-budget-status--red {
+  color: var(--red-600);
 }
 
 .category-budget-progress {
@@ -1830,6 +2015,12 @@ body {
   font-size: 0.875rem;
   color: var(--gray-700);
   margin-bottom: 0.25rem;
+}
+
+.category-budget-expected {
+  font-size: 0.75rem;
+  color: var(--gray-500);
+  margin-bottom: 0.35rem;
 }
 
 /* Progress bars for category budgets */
@@ -1848,7 +2039,15 @@ body {
   transition: width 0.3s ease;
 }
 
-.progress-fill.over {
+.progress-fill--green {
+  background: var(--green-500);
+}
+
+.progress-fill--yellow {
+  background: var(--yellow-400);
+}
+
+.progress-fill--red {
   background: var(--red-500);
 }
 


### PR DESCRIPTION
## Summary
- add a cadence-aware pacing helper that computes guardrail statuses for budgets and categories
- surface guardrail indicators and pacing copy on the budgets list and budget detail category rows
- extend styling with guardrail color tokens and badges for green, yellow, and red states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc5d6f10832ebdfcab7aa9437f0f