### PR TITLE
Add cadence selection flow and premium gating for budgets

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,7 @@ import Header from "./components/Header"
 import InstallPrompt from "./components/InstallPrompt"
 
 function AppContent() {
-  const { user, loading: authLoading, initializing } = useAuth()
+  const { user, userProfile, loading: authLoading, initializing } = useAuth()
   const [budgets, setBudgets] = useState([])
   const [categories, setCategories] = useState({
     income: [
@@ -59,6 +59,8 @@ function AppContent() {
             name: budget.name,
             createdAt: new Date(budget.created_at).toLocaleDateString(),
             categoryBudgets: budget.category_budgets || [],
+            cycleType: budget.cycle_type || "monthly",
+            cycleSettings: budget.cycle_settings || {},
             transactions:
               budget.transactions?.map((tx) => ({
                 id: tx.id,
@@ -137,6 +139,7 @@ function AppContent() {
           setViewMode={setViewMode}
           setBudgets={setBudgets}
           userId={user.id}
+          userProfile={userProfile}
         />
       )}
       {viewMode === "details" && selectedBudget && (

--- a/src/lib/supabase-mock.js
+++ b/src/lib/supabase-mock.js
@@ -319,10 +319,14 @@ export const getBudgets = async (userId) => {
 export const createBudget = async (userId, budgetData) => {
   await delay()
   const newBudget = {
-    ...budgetData,
     id: generateId(),
     user_id: userId,
+    name: budgetData.name,
+    category_budgets: budgetData.categoryBudgets || [],
+    cycle_type: budgetData.cycleType ?? "monthly",
+    cycle_settings: budgetData.cycleSettings ?? {},
     created_at: new Date().toISOString(),
+    transactions: [],
   }
 
   const existingBudgets = JSON.parse(localStorage.getItem(`budgets_${userId}`) || "[]")
@@ -339,7 +343,21 @@ export const updateBudget = async (budgetId, budgetData) => {
   const index = existingBudgets.findIndex((budget) => budget.id === budgetId)
 
   if (index > -1) {
-    existingBudgets[index] = { ...existingBudgets[index], ...budgetData }
+    const updated = {
+      ...existingBudgets[index],
+      name: budgetData.name,
+      category_budgets: budgetData.categoryBudgets || existingBudgets[index].category_budgets || [],
+    }
+
+    if (Object.prototype.hasOwnProperty.call(budgetData, "cycleType")) {
+      updated.cycle_type = budgetData.cycleType ?? "monthly"
+    }
+
+    if (Object.prototype.hasOwnProperty.call(budgetData, "cycleSettings")) {
+      updated.cycle_settings = budgetData.cycleSettings ?? {}
+    }
+
+    existingBudgets[index] = updated
     localStorage.setItem(`budgets_${userId}`, JSON.stringify(existingBudgets))
     return { data: [existingBudgets[index]], error: null }
   }

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -26,6 +26,7 @@ const DEMO_ADMIN = {
     user_metadata: {
       full_name: "Demo Admin",
     },
+    plan: "paid",
     created_at: new Date().toISOString(),
   },
   profile: {
@@ -204,6 +205,8 @@ export const createBudget = async (userId, budgetData) => {
       user_id: userId,
       name: budgetData.name,
       category_budgets: budgetData.categoryBudgets || [],
+      cycle_type: budgetData.cycleType ?? "monthly",
+      cycle_settings: budgetData.cycleSettings ?? {},
       created_at: new Date().toISOString(),
       transactions: [],
     }
@@ -218,6 +221,8 @@ export const createBudget = async (userId, budgetData) => {
         user_id: userId,
         name: budgetData.name,
         category_budgets: budgetData.categoryBudgets || [],
+        cycle_type: budgetData.cycleType ?? "monthly",
+        cycle_settings: budgetData.cycleSettings ?? {},
         created_at: new Date().toISOString(),
       },
     ])
@@ -230,22 +235,39 @@ export const updateBudget = async (budgetId, budgetData) => {
   if (budgetId.startsWith("demo-budget-")) {
     const budgetIndex = demoBudgets.findIndex((b) => b.id === budgetId)
     if (budgetIndex !== -1) {
-      demoBudgets[budgetIndex] = {
+      const updatedBudget = {
         ...demoBudgets[budgetIndex],
         name: budgetData.name,
         category_budgets: budgetData.categoryBudgets || [],
       }
+      if (Object.prototype.hasOwnProperty.call(budgetData, "cycleType")) {
+        updatedBudget.cycle_type = budgetData.cycleType ?? "monthly"
+      }
+      if (Object.prototype.hasOwnProperty.call(budgetData, "cycleSettings")) {
+        updatedBudget.cycle_settings = budgetData.cycleSettings ?? {}
+      }
+      demoBudgets[budgetIndex] = updatedBudget
       return { data: [demoBudgets[budgetIndex]], error: null }
     }
     return { data: null, error: { message: "Budget not found" } }
   }
 
+  const payload = {
+    name: budgetData.name,
+    category_budgets: budgetData.categoryBudgets || [],
+  }
+
+  if (Object.prototype.hasOwnProperty.call(budgetData, "cycleType")) {
+    payload.cycle_type = budgetData.cycleType ?? "monthly"
+  }
+
+  if (Object.prototype.hasOwnProperty.call(budgetData, "cycleSettings")) {
+    payload.cycle_settings = budgetData.cycleSettings ?? {}
+  }
+
   const { data, error } = await supabase
     .from("budgets")
-    .update({
-      name: budgetData.name,
-      category_budgets: budgetData.categoryBudgets || [],
-    })
+    .update(payload)
     .eq("id", budgetId)
     .select()
   return { data, error }

--- a/src/screens/BudgetDetailsScreen.jsx
+++ b/src/screens/BudgetDetailsScreen.jsx
@@ -30,6 +30,15 @@ export default function BudgetDetailsScreen({
 
   const [selectedSlice, setSelectedSlice] = useState(null)
 
+  const cycleType = (budget.cycleType || "monthly").toLowerCase()
+  const cycleLabels = {
+    monthly: "Monthly",
+    "per-paycheck": "Per-paycheck",
+    custom: "Custom",
+  }
+  const cycleLabel = cycleLabels[cycleType] || cycleLabels.custom
+  const cycleIsPremium = cycleType !== "monthly"
+
   const ITEMS_PER_PAGE = 7
 
   const resolveTypeKey = (typeOrTab) => {
@@ -122,6 +131,8 @@ export default function BudgetDetailsScreen({
       const { error } = await updateBudget(budget.id, {
         name: newName,
         categoryBudgets: budget.categoryBudgets,
+        cycleType: budget.cycleType,
+        cycleSettings: budget.cycleSettings,
       })
 
       if (error) {
@@ -311,6 +322,15 @@ export default function BudgetDetailsScreen({
         onChange={(e) => handleBudgetNameChange(e.target.value)}
         placeholder="Budget Name"
       />
+
+      <div className="budgetCycle" style={{ marginBottom: "1.5rem" }}>
+        Cycle: {cycleLabel}
+        {cycleIsPremium && (
+          <span className="cycle-option-lock" title="Pocket Budget Plus cadence" style={{ marginLeft: "0.35rem" }}>
+            🔒
+          </span>
+        )}
+      </div>
 
       {/* Budget Overview Section */}
       <div className="budget-overview-card">

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -1,13 +1,175 @@
 "use client"
 
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { createBudget, updateBudget, deleteBudget } from "../lib/supabase"
 
-export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode, setBudgets, userId }) {
+const cycleLabels = {
+  monthly: "Monthly",
+  "per-paycheck": "Per-paycheck",
+  custom: "Custom",
+}
+
+const premiumCycleTypes = new Set(["per-paycheck", "custom"])
+
+const upgradeMessages = {
+  "per-paycheck": "Upgrade to Pocket Budget Plus to plan every paycheck cycle.",
+  custom: "Upgrade to Pocket Budget Plus to unlock custom cadences.",
+}
+
+const createDefaultCycleSettings = (cycleType) => {
+  const today = new Date().toISOString()
+  switch (cycleType) {
+    case "per-paycheck":
+      return {
+        anchorDate: today,
+        frequency: "per-paycheck",
+      }
+    case "custom":
+      return {
+        anchorDate: today,
+        lengthInDays: 30,
+      }
+    default:
+      return {
+        anchorDate: today,
+      }
+  }
+}
+
+const transformBudgetRecord = (record) => ({
+  id: record.id,
+  name: record.name,
+  createdAt: new Date(record.created_at).toLocaleDateString(),
+  categoryBudgets: record.category_budgets || [],
+  cycleType: record.cycle_type || "monthly",
+  cycleSettings: record.cycle_settings || {},
+  transactions: record.transactions || [],
+})
+
+export default function BudgetsScreen({
+  budgets,
+  setSelectedBudget,
+  setViewMode,
+  setBudgets,
+  userId,
+  userProfile,
+}) {
   const [editingBudgetId, setEditingBudgetId] = useState(null)
   const [budgetNameInput, setBudgetNameInput] = useState("")
   const [openMenuId, setOpenMenuId] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [showCreateFlow, setShowCreateFlow] = useState(false)
+  const [newBudgetName, setNewBudgetName] = useState("My Budget")
+  const [selectedCycle, setSelectedCycle] = useState("monthly")
+  const [upgradeMessage, setUpgradeMessage] = useState("")
+
+  const isPaidUser = useMemo(() => {
+    if (userId === "demo-admin-user-id") {
+      return true
+    }
+
+    if (!userProfile) {
+      return false
+    }
+
+    const directFlags = [userProfile.isPaid, userProfile.is_paid, userProfile.isPremium, userProfile.is_premium]
+    if (directFlags.some(Boolean)) {
+      return true
+    }
+
+    const planValues = [
+      userProfile.plan,
+      userProfile.plan_tier,
+      userProfile.planTier,
+      userProfile.subscriptionTier,
+      userProfile.subscription,
+      userProfile.tier,
+      userProfile.membership,
+      userProfile.accountType,
+    ]
+
+    if (
+      planValues
+        .filter(Boolean)
+        .map((value) => value.toString().toLowerCase())
+        .some((value) => ["paid", "pro", "plus", "premium"].some((keyword) => value.includes(keyword)))
+    ) {
+      return true
+    }
+
+    const entitlementSources = [
+      userProfile.entitlements,
+      userProfile.feature_flags,
+      userProfile.features,
+      userProfile.featureFlags,
+    ]
+
+    for (const source of entitlementSources) {
+      if (!source) continue
+
+      if (Array.isArray(source)) {
+        const hasFlag = source.some((value) => {
+          if (typeof value !== "string") return false
+          const lower = value.toLowerCase()
+          return lower.includes("cadence") || lower.includes("schedule") || lower.includes("premium")
+        })
+        if (hasFlag) return true
+      } else if (typeof source === "object") {
+        const hasFlag = Object.values(source).some((value) => {
+          if (typeof value === "string") {
+            const lower = value.toLowerCase()
+            return lower.includes("cadence") || lower.includes("schedule") || lower.includes("premium")
+          }
+          return Boolean(value)
+        })
+        if (hasFlag) return true
+      }
+    }
+
+    return false
+  }, [userId, userProfile])
+
+  const canUseCycle = (cycleType) => !premiumCycleTypes.has(cycleType) || isPaidUser
+
+  const formatCycleLabel = (cycleType) => {
+    const normalized = (cycleType || "monthly").toLowerCase()
+    return cycleLabels[normalized] || cycleLabels.custom
+  }
+
+  const startCreateFlow = () => {
+    const generateDefaultName = () => {
+      const base = "My Budget"
+      const existingNames = new Set(budgets.map((b) => b.name))
+      if (!existingNames.has(base)) {
+        return base
+      }
+      let index = 2
+      while (existingNames.has(`${base} ${index}`)) {
+        index += 1
+      }
+      return `${base} ${index}`
+    }
+
+    setNewBudgetName(generateDefaultName())
+    setSelectedCycle("monthly")
+    setUpgradeMessage("")
+    setShowCreateFlow(true)
+  }
+
+  const cancelCreateFlow = () => {
+    setShowCreateFlow(false)
+    setUpgradeMessage("")
+  }
+
+  const handleCycleSelect = (cycleType) => {
+    const normalized = cycleType.toLowerCase()
+    if (!canUseCycle(normalized)) {
+      setUpgradeMessage(upgradeMessages[normalized] || "Upgrade to unlock this cadence.")
+      return
+    }
+    setSelectedCycle(normalized)
+    setUpgradeMessage("")
+  }
 
   const openBudget = (budget) => {
     setSelectedBudget(budget)
@@ -15,11 +177,23 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
   }
 
   const createNewBudget = async () => {
+    if (!newBudgetName.trim()) {
+      setUpgradeMessage("Give your budget a name to continue.")
+      return
+    }
+
+    if (!canUseCycle(selectedCycle)) {
+      setUpgradeMessage(upgradeMessages[selectedCycle] || "Upgrade to unlock this cadence.")
+      return
+    }
+
     setLoading(true)
     try {
       const newBudgetData = {
-        name: `My Budget`,
+        name: newBudgetName.trim(),
         categoryBudgets: [],
+        cycleType: selectedCycle,
+        cycleSettings: createDefaultCycleSettings(selectedCycle),
       }
 
       const { data, error } = await createBudget(userId, newBudgetData)
@@ -27,14 +201,10 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
         console.error("Error creating budget:", error)
         alert("Failed to create budget. Please try again.")
       } else if (data?.[0]) {
-        const newBudget = {
-          id: data[0].id,
-          name: data[0].name,
-          createdAt: new Date(data[0].created_at).toLocaleDateString(),
-          categoryBudgets: data[0].category_budgets || [],
-          transactions: [],
-        }
+        const newBudget = transformBudgetRecord(data[0])
         setBudgets([newBudget, ...budgets])
+        setShowCreateFlow(false)
+        setUpgradeMessage("")
       }
     } catch (error) {
       console.error("Error creating budget:", error)
@@ -55,6 +225,8 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
       const { error } = await updateBudget(budget.id, {
         name: budgetNameInput.trim(),
         categoryBudgets: budget.categoryBudgets,
+        cycleType: budget.cycleType,
+        cycleSettings: budget.cycleSettings,
       })
 
       if (error) {
@@ -76,9 +248,17 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
   const duplicateBudget = async (budget) => {
     setLoading(true)
     try {
+      const cycleType = (budget.cycleType || "monthly").toLowerCase()
+      if (!canUseCycle(cycleType)) {
+        alert(upgradeMessages[cycleType] || "Upgrade to duplicate budgets with this cadence.")
+        return
+      }
+
       const duplicateData = {
         name: `${budget.name} (Copy)`,
         categoryBudgets: budget.categoryBudgets || [],
+        cycleType,
+        cycleSettings: budget.cycleSettings || createDefaultCycleSettings(cycleType),
       }
 
       const { data, error } = await createBudget(userId, duplicateData)
@@ -86,13 +266,7 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
         console.error("Error duplicating budget:", error)
         alert("Failed to duplicate budget. Please try again.")
       } else if (data?.[0]) {
-        const newBudget = {
-          id: data[0].id,
-          name: data[0].name,
-          createdAt: new Date(data[0].created_at).toLocaleDateString(),
-          categoryBudgets: data[0].category_budgets || [],
-          transactions: [],
-        }
+        const newBudget = transformBudgetRecord(data[0])
         setBudgets([newBudget, ...budgets])
       }
     } catch (error) {
@@ -123,6 +297,147 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
     }
   }
 
+  const renderCreateFlow = () => {
+    if (!showCreateFlow) return null
+
+    const cycles = [
+      {
+        type: "monthly",
+        title: "Monthly",
+        description: "Reset your budget every calendar month.",
+        icon: "📅",
+      },
+      {
+        type: "per-paycheck",
+        title: "Per-paycheck",
+        description: "Plan every paycheck and manage mid-cycle cash flow.",
+        icon: "💼",
+      },
+      {
+        type: "custom",
+        title: "Custom",
+        description: "Choose bespoke anchors and durations for any workflow.",
+        icon: "⚙️",
+      },
+    ]
+
+    return (
+      <div
+        className="create-budget-panel"
+        style={{
+          marginBottom: "2rem",
+          padding: "1.5rem",
+          borderRadius: "1rem",
+          background: "var(--card-bg, #ffffff)",
+          boxShadow: "0 12px 30px rgba(15, 23, 42, 0.08)",
+        }}
+      >
+        <h3 className="overview-title" style={{ marginBottom: "1rem" }}>
+          Create a New Budget
+        </h3>
+        <label className="stat-label" htmlFor="budget-name-input">
+          Budget name
+        </label>
+        <input
+          id="budget-name-input"
+          className="input budget-name-input"
+          value={newBudgetName}
+          onChange={(e) => setNewBudgetName(e.target.value)}
+          placeholder="My Budget"
+          disabled={loading}
+        />
+
+        <div className="cycle-options" style={{ marginTop: "1.5rem" }}>
+          <p className="chart-section-title" style={{ marginBottom: "0.5rem" }}>
+            Choose your budget cadence
+          </p>
+          <div
+            className="cycle-options-grid"
+            style={{
+              display: "grid",
+              gap: "1rem",
+              gridTemplateColumns: "repeat(auto-fit, minmax(210px, 1fr))",
+            }}
+          >
+            {cycles.map((cycle) => {
+              const normalized = cycle.type.toLowerCase()
+              const isPremium = premiumCycleTypes.has(normalized)
+              const isLocked = isPremium && !isPaidUser
+              const isActive = selectedCycle === normalized && !isLocked
+
+              return (
+                <button
+                  key={cycle.type}
+                  type="button"
+                  className={`cycle-option ${isActive ? "active" : ""} ${isLocked ? "locked" : ""}`}
+                  onClick={() => handleCycleSelect(normalized)}
+                  disabled={loading}
+                  style={{
+                    textAlign: "left",
+                    border: isActive ? "2px solid #6366f1" : "1px solid rgba(148, 163, 184, 0.4)",
+                    borderRadius: "0.75rem",
+                    padding: "1rem",
+                    background: isActive ? "rgba(99, 102, 241, 0.08)" : "rgba(255,255,255,0.02)",
+                    cursor: isLocked ? "not-allowed" : "pointer",
+                    opacity: isLocked ? 0.6 : 1,
+                    transition: "border 0.2s ease, background 0.2s ease",
+                  }}
+                >
+                  <div className="cycle-option-header" style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+                    <span className="cycle-option-icon" style={{ fontSize: "1.25rem" }}>
+                      {cycle.icon}
+                    </span>
+                    <span className="cycle-option-title" style={{ fontWeight: 600 }}>
+                      {cycle.title}
+                    </span>
+                    {isPremium && (
+                      <span className="cycle-option-lock" title="Pocket Budget Plus required">
+                        🔒
+                      </span>
+                    )}
+                  </div>
+                  <p className="cycle-option-description" style={{ marginTop: "0.5rem", color: "#475569" }}>
+                    {cycle.description}
+                  </p>
+                  {isLocked && (
+                    <p className="cycle-option-upgrade" style={{ marginTop: "0.75rem", color: "#b91c1c", fontWeight: 600 }}>
+                      Upgrade required
+                    </p>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {upgradeMessage && (
+          <div
+            className="upgrade-callout"
+            style={{
+              marginTop: "1rem",
+              padding: "0.75rem 1rem",
+              borderRadius: "0.75rem",
+              background: "#fef3c7",
+              color: "#92400e",
+              fontWeight: 600,
+            }}
+          >
+            <span>🚀 {upgradeMessage}</span>
+          </div>
+        )}
+
+        <div className="budget-actions" style={{ marginTop: "1rem" }}>
+          <button className="addButton primary-button" onClick={createNewBudget} disabled={loading}>
+            {loading ? "Creating..." : "Create Budget"}
+          </button>
+          <button className="cancelButton secondary-button" onClick={cancelCreateFlow} disabled={loading}>
+            Cancel
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div>
       <div className="header-section">
@@ -132,40 +447,51 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
       {budgets.length === 0 ? (
         <div className="empty-state">
           <p>Welcome to Pocket Budget! Create your first budget to get started.</p>
-          <button className="primary-button" onClick={createNewBudget} disabled={loading}>
-            {loading ? "Creating..." : "Create Your First Budget"}
-          </button>
+          {showCreateFlow ? (
+            renderCreateFlow()
+          ) : (
+            <button className="primary-button" onClick={startCreateFlow} disabled={loading}>
+              Start Your First Budget
+            </button>
+          )}
         </div>
       ) : (
-        budgets.map((budget) => {
-          const totalIncome = (budget.transactions || [])
-            .filter((t) => t.type === "income")
-            .reduce((sum, t) => sum + t.amount, 0)
-
-          const totalExpenses = (budget.transactions || [])
-            .filter((t) => t.type === "expense")
-            .reduce((sum, t) => sum + t.amount, 0)
-
-          const balance = totalIncome - totalExpenses
-
-          // Category budget summaries
-          const categorySummaries = (budget.categoryBudgets || []).map((cat) => {
-            const actual = (budget.transactions || [])
-              .filter(
-                (t) => t.type === "expense" && t.category.toLowerCase().trim() === cat.category.toLowerCase().trim(),
-              )
+        <>
+          {renderCreateFlow()}
+          {budgets.map((budget) => {
+            const totalIncome = (budget.transactions || [])
+              .filter((t) => t.type === "income")
               .reduce((sum, t) => sum + t.amount, 0)
 
-            const isOver = actual > cat.budgetedAmount
-            return { ...cat, actual, isOver }
-          })
+            const totalExpenses = (budget.transactions || [])
+              .filter((t) => t.type === "expense")
+              .reduce((sum, t) => sum + t.amount, 0)
 
-          const isAnyCategoryOver = categorySummaries.some((cat) => cat.isOver)
+            const balance = totalIncome - totalExpenses
 
-          return (
-            <div key={budget.id} className="budgetCard">
-              <div className="budgetCard-content">
-                <div className="budgetCard-info" onClick={() => openBudget(budget)}>
+            // Category budget summaries
+            const categorySummaries = (budget.categoryBudgets || []).map((cat) => {
+              const actual = (budget.transactions || [])
+                .filter(
+                  (t) =>
+                    t.type === "expense" && t.category.toLowerCase().trim() === cat.category.toLowerCase().trim(),
+                )
+                .reduce((sum, t) => sum + t.amount, 0)
+
+              const isOver = actual > cat.budgetedAmount
+              return { ...cat, actual, isOver }
+            })
+
+            const isAnyCategoryOver = categorySummaries.some((cat) => cat.isOver)
+
+            const cycleType = (budget.cycleType || "monthly").toLowerCase()
+            const displayCycle = formatCycleLabel(cycleType)
+            const isPremiumCycle = premiumCycleTypes.has(cycleType)
+
+            return (
+              <div key={budget.id} className="budgetCard">
+                <div className="budgetCard-content">
+                  <div className="budgetCard-info" onClick={() => openBudget(budget)}>
                   {editingBudgetId === budget.id ? (
                     <input
                       className="input budget-name-input"
@@ -200,6 +526,15 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
 
                   <div className="budgetBalance">
                     Balance: <span className={balance >= 0 ? "income" : "expense"}>${balance.toFixed(2)}</span>
+                  </div>
+
+                  <div className="budgetCycle">
+                    Cycle: {displayCycle}
+                    {isPremiumCycle && (
+                      <span className="cycle-option-lock" title="Pocket Budget Plus cadence" style={{ marginLeft: "0.35rem" }}>
+                        🔒
+                      </span>
+                    )}
                   </div>
 
                   <div className="budgetDate">Created: {budget.createdAt}</div>
@@ -277,16 +612,17 @@ export default function BudgetsScreen({ budgets, setSelectedBudget, setViewMode,
                     </div>
                   )}
                 </div>
+                </div>
               </div>
-            </div>
-          )
-        })
+            )
+          })}
+        </>
       )}
 
       {budgets.length > 0 && (
         <div className="budget-actions">
-          <button className="addButton primary-button" onClick={createNewBudget} disabled={loading}>
-            {loading ? "Creating..." : "Create New Budget"}
+          <button className="addButton primary-button" onClick={startCreateFlow} disabled={loading}>
+            Create New Budget
           </button>
           <button className="cancelButton secondary-button cate-btn" onClick={() => setViewMode("categories")}>
             Manage Categories


### PR DESCRIPTION
## Summary
- add cadence metadata to Supabase budget CRUD so cycle type and settings persist for demo and real users
- redesign the budget creation experience with cadence picker, upgrade messaging, and premium gating logic
- surface each budget's cadence (with lock indicators) on list cards and detail headers while preserving entitlement-aware updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc5e1c70832eaf7d2b7cc80f989d