### PR TITLE
Add subscription entitlements and upgrade prompts

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { signOut } from "../lib/supabase-mock"
+import { signOut } from "../lib/supabase"
 import { useAuth } from "../contexts/AuthContext"
 
 export default function Header({ title, showLogout = false }) {

--- a/src/components/UpgradeBanner.jsx
+++ b/src/components/UpgradeBanner.jsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react"
+import { formatPlanPrice, getPrimaryPaidPlan } from "../lib/plans"
+
+const formatCountdown = (targetDate) => {
+  if (!targetDate) return ""
+  const diff = targetDate.getTime() - Date.now()
+  if (diff <= 0) {
+    return "Ending soon"
+  }
+
+  const totalSeconds = Math.floor(diff / 1000)
+  const days = Math.floor(totalSeconds / (60 * 60 * 24))
+  const hours = Math.floor((totalSeconds % (60 * 60 * 24)) / (60 * 60))
+  const minutes = Math.floor((totalSeconds % (60 * 60)) / 60)
+  const seconds = totalSeconds % 60
+
+  if (days > 0) {
+    return `${days}d ${hours}h ${minutes}m`
+  }
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`
+  }
+
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`
+  }
+
+  return `${seconds}s`
+}
+
+export default function UpgradeBanner({
+  variant = "trial",
+  plan: planProp,
+  trialEndsAt,
+  isTrialActive = false,
+  onUpgrade,
+  onDismiss,
+  secondaryAction,
+  headline,
+  message,
+  className = "",
+}) {
+  const plan = useMemo(() => planProp ?? getPrimaryPaidPlan(), [planProp])
+  const trialEndDate = trialEndsAt ? new Date(trialEndsAt) : null
+  const [countdown, setCountdown] = useState(() => (trialEndDate ? formatCountdown(trialEndDate) : ""))
+
+  useEffect(() => {
+    if (variant !== "trial" || !trialEndDate) {
+      return
+    }
+
+    setCountdown(formatCountdown(trialEndDate))
+    const timer = setInterval(() => {
+      setCountdown(formatCountdown(trialEndDate))
+    }, 1000)
+
+    return () => clearInterval(timer)
+  }, [variant, trialEndDate])
+
+  const eyebrowText = variant === "trial" ? "Pocket Plus trial" : plan?.name
+  const defaultHeadline =
+    headline ||
+    (variant === "trial" ? "Enjoying Pocket Plus?" : `Unlock ${plan?.name ?? "premium"} features`)
+  const defaultMessage =
+    message ||
+    (variant === "trial"
+      ? "Upgrade before your trial ends to keep your AI insights and ad-free experience."
+      : "Pocket Plus includes AI Finance Reports, ad-free budgeting, and more power features for serious planners.")
+  const ctaLabel = variant === "trial" ? "Upgrade now" : `Upgrade to ${plan?.name ?? "Pocket Plus"}`
+  const priceLabel = formatPlanPrice(plan)
+
+  return (
+    <div className={`upgrade-banner upgrade-banner--${variant} ${className}`.trim()}>
+      <div className="upgrade-banner__content">
+        <div className="upgrade-banner__header">
+          <div className="upgrade-banner__eyebrow">{eyebrowText}</div>
+          <h3 className="upgrade-banner__headline">{defaultHeadline}</h3>
+          <p className="upgrade-banner__message">{defaultMessage}</p>
+          <div className="upgrade-banner__price">{priceLabel}</div>
+          {variant === "trial" && isTrialActive && countdown && (
+            <div className="upgrade-countdown">
+              Trial ends in <strong>{countdown}</strong>
+            </div>
+          )}
+        </div>
+
+        {plan?.features?.length ? (
+          <ul className="upgrade-feature-list">
+            {plan.features.map((feature) => (
+              <li key={feature} className="upgrade-feature-item">
+                <span className="upgrade-feature-icon">✨</span>
+                <span>{feature}</span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <div className="upgrade-banner__actions">
+          <button
+            className="primary-button upgrade-banner__cta"
+            onClick={onUpgrade}
+            disabled={!onUpgrade}
+            type="button"
+          >
+            {ctaLabel}
+          </button>
+          {secondaryAction ? (
+            <button
+              className="secondary-button upgrade-banner__secondary"
+              onClick={secondaryAction.onClick}
+              type="button"
+            >
+              {secondaryAction.label}
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      {onDismiss ? (
+        <button className="upgrade-banner__dismiss" onClick={onDismiss} aria-label="Dismiss upgrade notice" type="button">
+          ✕
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,7 +1,17 @@
 "use client"
 
 import { createContext, useContext, useEffect, useState } from "react"
-import { supabase, getCurrentUser, createUserProfile, getUserProfile } from "../lib/supabase"
+import {
+  supabase,
+  getCurrentUser,
+  createUserProfile,
+  getUserProfile,
+  updateUserProfile,
+  getUserSubscription,
+  upsertUserSubscription,
+  cancelUserSubscription,
+} from "../lib/supabase"
+import { PLAN_IDS, calculateTrialEndDate, getPlanById, getPrimaryPaidPlan, isPaidPlan } from "../lib/plans"
 
 const AuthContext = createContext({})
 
@@ -16,6 +26,7 @@ export function useAuth() {
 export function AuthProvider({ children }) {
   const [user, setUser] = useState(null)
   const [userProfile, setUserProfile] = useState(null)
+  const [subscription, setSubscription] = useState(null)
   const [loading, setLoading] = useState(true)
   const [initializing, setInitializing] = useState(true)
 
@@ -71,6 +82,7 @@ export function AuthProvider({ children }) {
           await loadUserProfile(session.user.id)
         } else {
           setUserProfile(null)
+          setSubscription(null)
         }
       } catch (error) {
         console.error("Error handling auth state change:", error)
@@ -96,6 +108,7 @@ export function AuthProvider({ children }) {
           await loadUserProfile(session.user.id)
         } else {
           setUserProfile(null)
+          setSubscription(null)
         }
       } catch (error) {
         console.error("Error handling demo auth state change:", error)
@@ -118,34 +131,166 @@ export function AuthProvider({ children }) {
 
   const loadUserProfile = async (userId) => {
     try {
+      let resolvedProfile = null
       const { data: profile, error } = await getUserProfile(userId)
 
       if (error && error.code === "PGRST116") {
         // Profile doesn't exist, create it
-        const user = await getCurrentUser()
-        if (user.user) {
+        const current = await getCurrentUser()
+        if (current.user) {
           const { data: newProfile } = await createUserProfile(
-            user.user.id,
-            user.user.email,
-            user.user.user_metadata?.full_name || user.user.email,
+            current.user.id,
+            current.user.email,
+            current.user.user_metadata?.full_name || current.user.email,
           )
-          setUserProfile(newProfile?.[0] || null)
+          resolvedProfile = newProfile?.[0] || null
         }
       } else if (!error) {
-        setUserProfile(profile)
+        resolvedProfile = profile
+      }
+
+      if (resolvedProfile) {
+        setUserProfile(resolvedProfile)
+      }
+
+      if (error && error.code !== "PGRST116") {
+        console.error("Error loading user profile:", error)
+      }
+
+      const { data: subscriptionData, error: subscriptionError } = await getUserSubscription(userId)
+
+      if (subscriptionError && subscriptionError.code && subscriptionError.code !== "PGRST116") {
+        console.error("Error loading subscription:", subscriptionError)
+      }
+
+      if (subscriptionData) {
+        setSubscription(subscriptionData)
+      } else if (resolvedProfile) {
+        // Seed a default subscription record so entitlement calculations stay consistent
+        const trialEndsAt = resolvedProfile.trial_ends_at ?? null
+        const isTrialActive = trialEndsAt ? new Date(trialEndsAt).getTime() > Date.now() : false
+        const status = isPaidPlan(resolvedProfile.plan) ? "active" : isTrialActive ? "trialing" : "inactive"
+
+        const { data: seededSubscription, error: seedError } = await upsertUserSubscription(userId, {
+          plan: resolvedProfile.plan ?? PLAN_IDS.FREE,
+          status,
+          trial_ends_at: trialEndsAt,
+          ads_enabled: resolvedProfile.ads_enabled ?? true,
+        })
+
+        if (!seedError) {
+          setSubscription(seededSubscription)
+        } else {
+          console.error("Error creating default subscription record:", seedError)
+          setSubscription(null)
+        }
+      } else {
+        setSubscription(null)
       }
     } catch (error) {
       console.error("Error loading user profile:", error)
       // Don't block the app if profile loading fails
       setUserProfile(null)
+      setSubscription(null)
     }
   }
+
+  const refreshSubscription = async () => {
+    if (!user) {
+      return { data: null, error: new Error("Not authenticated") }
+    }
+
+    const { data, error } = await getUserSubscription(user.id)
+
+    if (!error) {
+      setSubscription(data)
+    }
+
+    return { data, error }
+  }
+
+  const applyProfileSync = async (updates) => {
+    if (!user) return
+
+    setUserProfile((prev) => (prev ? { ...prev, ...updates } : prev))
+    try {
+      await updateUserProfile(user.id, updates)
+    } catch (error) {
+      console.error("Failed to persist profile updates:", error)
+    }
+  }
+
+  const upgradeToPlan = async (planId, { startTrial = false } = {}) => {
+    if (!user) {
+      return { data: null, error: new Error("Not authenticated") }
+    }
+
+    const trialEndsAt = startTrial ? calculateTrialEndDate().toISOString() : null
+
+    const { data, error } = await upsertUserSubscription(user.id, {
+      plan: planId,
+      status: "active",
+      trial_ends_at: startTrial ? trialEndsAt : null,
+      ads_enabled: isPaidPlan(planId) ? false : true,
+    })
+
+    if (!error) {
+      setSubscription(data)
+      await applyProfileSync({
+        plan: data?.plan ?? planId,
+        trial_ends_at: data?.trial_ends_at ?? (startTrial ? trialEndsAt : null),
+        ads_enabled: data?.ads_enabled ?? (isPaidPlan(planId) ? false : true),
+      })
+    }
+
+    return { data, error }
+  }
+
+  const downgradeToFree = async () => {
+    if (!user) {
+      return { data: null, error: new Error("Not authenticated") }
+    }
+
+    const { data, error } = await cancelUserSubscription(user.id)
+
+    if (!error) {
+      setSubscription(data)
+      await applyProfileSync({
+        plan: PLAN_IDS.FREE,
+        trial_ends_at: null,
+        ads_enabled: true,
+      })
+    }
+
+    return { data, error }
+  }
+
+  const planId = subscription?.plan || userProfile?.plan || PLAN_IDS.FREE
+  const planInfo = getPlanById(planId)
+  const adsEnabled = subscription?.ads_enabled ?? userProfile?.ads_enabled ?? true
+  const trialEndsAt = subscription?.trial_ends_at || userProfile?.trial_ends_at || null
+  const trialEndDate = trialEndsAt ? new Date(trialEndsAt) : null
+  const isTrialActive = trialEndDate ? trialEndDate.getTime() > Date.now() : false
+  const subscriptionStatus = subscription?.status || (isPaidPlan(planId) ? "active" : isTrialActive ? "trialing" : "inactive")
+  const isPaid = isPaidPlan(planId) && subscriptionStatus === "active"
+  const primaryPaidPlan = getPrimaryPaidPlan()
 
   const value = {
     user,
     userProfile,
+    subscription,
     loading,
     initializing,
+    plan: planId,
+    planInfo,
+    isPaid,
+    isTrialActive,
+    trialEndsAt,
+    adsEnabled,
+    upgradeToPlan,
+    downgradeToFree,
+    refreshSubscription,
+    primaryPaidPlan,
   }
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/lib/plans.js
+++ b/src/lib/plans.js
@@ -1,0 +1,59 @@
+export const PLAN_IDS = {
+  FREE: "free",
+  PLUS: "plus",
+}
+
+export const TRIAL_PERIOD_DAYS = 7
+
+export const PLANS = {
+  [PLAN_IDS.FREE]: {
+    id: PLAN_IDS.FREE,
+    name: "Pocket Free",
+    price: 0,
+    priceLabel: "Free",
+    description: "Great for getting started with budgeting basics.",
+    features: [
+      "Unlimited budgets",
+      "Manual transaction tracking",
+      "Custom categories",
+    ],
+  },
+  [PLAN_IDS.PLUS]: {
+    id: PLAN_IDS.PLUS,
+    name: "Pocket Plus",
+    price: 9,
+    priceLabel: "$9/mo",
+    description: "Unlock AI-powered insights and an ad-free experience.",
+    features: [
+      "AI Finance Reports",
+      "Ad-free experience",
+      "Priority email support",
+    ],
+  },
+}
+
+export const FEATURE_ACCESS = {
+  aiInsights: PLAN_IDS.PLUS,
+}
+
+export const PRIMARY_PAID_PLAN_ID = PLAN_IDS.PLUS
+
+export const getPlanById = (planId) => PLANS[planId] ?? PLANS[PLAN_IDS.FREE]
+
+export const getPrimaryPaidPlan = () => PLANS[PRIMARY_PAID_PLAN_ID]
+
+export const isPaidPlan = (planId) => planId && planId !== PLAN_IDS.FREE
+
+export const formatPlanPrice = (plan) => {
+  if (!plan) return ""
+  if (!plan.price || plan.price === 0) {
+    return "Free"
+  }
+  return plan.priceLabel ?? `$${plan.price}/mo`
+}
+
+export const calculateTrialEndDate = (start = new Date()) => {
+  const end = new Date(start)
+  end.setDate(end.getDate() + TRIAL_PERIOD_DAYS)
+  return end
+}

--- a/src/screens/BudgetDetailsScreen.jsx
+++ b/src/screens/BudgetDetailsScreen.jsx
@@ -11,6 +11,8 @@ export default function BudgetDetailsScreen({
   budgets,
   setSelectedBudget,
   userId,
+  onRequestAi,
+  canAccessAi = true,
 }) {
   const [tab, setTab] = useState("expenses")
   const [showModal, setShowModal] = useState(false)
@@ -300,8 +302,13 @@ export default function BudgetDetailsScreen({
         <button className="cancelButton secondary-button" onClick={() => setViewMode("budgets")}>
           ← Back
         </button>
-        <button className="ai-insights-button primary-button" onClick={() => setViewMode("ai")}>
-          🧠 AI Finance Report
+        <button
+          className={`ai-insights-button primary-button${canAccessAi ? "" : " locked"}`}
+          onClick={() => (onRequestAi ? onRequestAi() : setViewMode("ai"))}
+          type="button"
+          title={canAccessAi ? "Open AI Finance Report" : "Upgrade to unlock AI Finance Reports"}
+        >
+          {canAccessAi ? "🧠 AI Finance Report" : "Unlock AI Finance Report"}
         </button>
       </div>
 

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -122,6 +122,129 @@
   background: rgba(255, 255, 255, 0.1);
 }
 
+.upgrade-banner {
+  margin: 1rem 0;
+  padding: 1.25rem;
+  border-radius: var(--radius-xl);
+  color: white;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+}
+
+.upgrade-banner--upsell {
+  background: linear-gradient(135deg, var(--primary-600), var(--primary-800));
+}
+
+.upgrade-banner__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.upgrade-banner__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.upgrade-banner__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  opacity: 0.85;
+}
+
+.upgrade-banner__headline {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.upgrade-banner__message {
+  margin: 0;
+  font-size: 0.9rem;
+  opacity: 0.9;
+}
+
+.upgrade-banner__price {
+  font-size: 0.875rem;
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.upgrade-countdown {
+  font-size: 0.85rem;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 0.3rem 0.75rem;
+  border-radius: var(--radius-full);
+  width: fit-content;
+}
+
+.upgrade-feature-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.35rem 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.upgrade-feature-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  opacity: 0.95;
+}
+
+.upgrade-feature-icon {
+  font-size: 0.9rem;
+}
+
+.upgrade-banner__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.upgrade-banner__cta,
+.upgrade-banner__secondary {
+  width: auto;
+  min-width: 9.5rem;
+}
+
+.upgrade-banner__secondary {
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.upgrade-banner__secondary:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.upgrade-banner__dismiss {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: var(--radius-full);
+  border: none;
+  background: rgba(255, 255, 255, 0.18);
+  color: white;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.upgrade-banner__dismiss:hover {
+  background: rgba(255, 255, 255, 0.3);
+}
+
 /* PWA Standalone Mode Adjustments */
 @media (display-mode: standalone) {
   body {
@@ -2371,6 +2494,18 @@ select.input {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+}
+
+.ai-insights-button.locked {
+  background: rgba(255, 255, 255, 0.15);
+  color: var(--primary-50);
+  border: 1px dashed rgba(255, 255, 255, 0.35);
+  box-shadow: none;
+}
+
+.ai-insights-button.locked:hover {
+  background: rgba(255, 255, 255, 0.25);
+  transform: none;
 }
 
 .header-nav {


### PR DESCRIPTION
## Summary
- add shared plan constants and an upgrade banner component for consistent upgrade messaging
- extend Supabase helpers and the auth context to track plan, trial, and ad entitlements with upgrade and downgrade actions
- gate the AI insights flow with upgrade prompts and surface a global trial banner for eligible users

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6cc61f62c832eb605fb759d6c1121