### PR TITLE
Add mobile bottom navigation footer

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import LoadingScreen from "./components/LoadingScreen"
 import LoginScreen from "./screens/LoginScreen"
 import Header from "./components/Header"
 import InstallPrompt from "./components/InstallPrompt"
+import Footer from "./components/Footer"
 import {
   createDefaultBudgetMetadata,
   getBudgetMetadata,
@@ -274,8 +275,9 @@ function AppContent() {
           setViewMode={setViewMode}
         />
       )}
-
       {viewMode === "ai" && activeBudget && <AIInsightsScreen budget={activeBudget} setViewMode={setViewMode} />}
+
+      <Footer viewMode={viewMode} setViewMode={setViewMode} />
     </div>
   )
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,85 @@
-export default function Footer() {
-    return (
-        <div className="fds-footer">
-            <p className="tagline">🏆 Greatness Magnified - Made with ❤️</p>
-        </div>
-    )
+import PropTypes from "prop-types"
+
+const NAV_ITEMS = [
+  { key: "home", label: "Home", icon: "🏠" },
+  { key: "budgets", label: "Budgets", icon: "💼" },
+  { key: "goals", label: "Goals", icon: "🎯" },
+  { key: "reports", label: "Reports", icon: "📊" },
+  { key: "settings", label: "Settings", icon: "⚙️" },
+]
+
+const keyToViewMode = {
+  home: "budgets",
+  budgets: "budgets",
+  goals: "goals",
+  reports: "ai",
+  settings: "settings",
+}
+
+const getActiveKey = (viewMode) => {
+  if (!viewMode) return "home"
+
+  switch (viewMode) {
+    case "budgets":
+    case "details":
+    case "categories":
+      return "budgets"
+    case "goals":
+      return "goals"
+    case "ai":
+    case "reports":
+      return "reports"
+    case "settings":
+    case "profile":
+      return "settings"
+    default:
+      return viewMode
+  }
+}
+
+export default function Footer({ viewMode, setViewMode, onSelect }) {
+  const activeKey = getActiveKey(viewMode)
+
+  const handleSelect = (key) => {
+    onSelect?.(key)
+
+    if (setViewMode) {
+      const nextView = keyToViewMode[key] || key
+      setViewMode(nextView)
+    }
+  }
+
+  return (
+    <nav className="bottom-nav" aria-label="Primary navigation">
+      {NAV_ITEMS.map((item) => {
+        const isActive = item.key === activeKey
+        return (
+          <button
+            key={item.key}
+            type="button"
+            className={`bottom-nav__item${isActive ? " is-active" : ""}`}
+            onClick={() => handleSelect(item.key)}
+            aria-pressed={isActive}
+          >
+            <span className="bottom-nav__icon" aria-hidden="true">
+              {item.icon}
+            </span>
+            <span className="bottom-nav__label">{item.label}</span>
+          </button>
+        )
+      })}
+    </nav>
+  )
+}
+
+Footer.propTypes = {
+  viewMode: PropTypes.string,
+  setViewMode: PropTypes.func,
+  onSelect: PropTypes.func,
+}
+
+Footer.defaultProps = {
+  viewMode: "budgets",
+  setViewMode: undefined,
+  onSelect: undefined,
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -38,12 +38,14 @@
   --radius-lg: 0.75rem;
   --radius-xl: 1rem;
   --radius-full: 9999px;
+
+  --bottom-nav-height: 4.5rem;
 }
 
 /* PWA Install Prompt */
 .install-prompt {
   position: fixed;
-  bottom: 1rem;
+  bottom: max(1rem, calc(var(--bottom-nav-height) + 1rem));
   left: 1rem;
   right: 1rem;
   background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
@@ -186,9 +188,77 @@ body {
   max-width: 28rem;
   margin: 0 auto;
   padding: 1.5rem;
+  padding-bottom: calc(var(--bottom-nav-height) + 2.5rem);
   background-color: var(--gray-50);
   min-height: 100vh;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.bottom-nav {
+  position: fixed;
+  left: 50%;
+  bottom: max(0.75rem, calc(env(safe-area-inset-bottom) * 0.5));
+  transform: translateX(-50%);
+  width: min(calc(100% - 2rem), 28rem);
+  padding: 0.5rem 1.25rem;
+  padding-bottom: calc(0.5rem + env(safe-area-inset-bottom));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.25rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 2rem;
+  box-shadow: var(--shadow-xl);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  z-index: 95;
+}
+
+.bottom-nav__item {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--gray-500);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.2rem;
+  padding: 0.35rem 0.25rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: var(--radius-lg);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.bottom-nav__icon {
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.bottom-nav__label {
+  font-size: 0.7rem;
+  letter-spacing: 0.01em;
+}
+
+.bottom-nav__item:hover {
+  background: rgba(14, 165, 233, 0.08);
+  color: var(--primary-600);
+}
+
+.bottom-nav__item:focus-visible {
+  outline: 2px solid var(--primary-500);
+  outline-offset: 2px;
+}
+
+.bottom-nav__item.is-active {
+  background: rgba(14, 165, 233, 0.16);
+  color: var(--primary-700);
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.18);
 }
 
 .loading-container {
@@ -1532,7 +1602,7 @@ body {
 /* Floating Action Button (FAB) */
 .fab {
   position: fixed;
-  bottom: 1.5rem;
+  bottom: calc(1.5rem + var(--bottom-nav-height));
   right: 1.5rem;
   width: 3.5rem;
   height: 3.5rem;
@@ -2421,6 +2491,7 @@ body {
 @media (max-width: 480px) {
   .container {
     padding: 1rem;
+    padding-bottom: calc(var(--bottom-nav-height) + 2rem);
   }
 
   .header {
@@ -2441,7 +2512,7 @@ body {
   }
 
   .fab {
-    bottom: 1rem;
+    bottom: calc(1rem + var(--bottom-nav-height));
     right: 1rem;
   }
 


### PR DESCRIPTION
## Summary
- replace the footer component with a bottom navigation bar that exposes callbacks for view selection
- render the footer within the main app shell so tapping tabs swaps the current screen
- extend global styles to pin the navigation to the bottom, highlight the active tab, and keep clearances for the floating action button

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d71deab64c832ea72c8ecfdde6f637