### PR TITLE
Update demo login credentials

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -20,8 +20,8 @@ const storage = typeof window !== "undefined" ? window.localStorage : null
 
 const DEMO_ADMIN = {
   id: "demo-admin-user-id",
-  email: "test@me.com",
-  password: "pass123",
+  email: "fulltest@test.com",
+  password: "tester_full",
   name: "Demo Admin",
 }
 

--- a/src/screens/LoginScreen.jsx
+++ b/src/screens/LoginScreen.jsx
@@ -16,7 +16,7 @@ export default function LoginScreen() {
     setError("")
 
     try {
-      const { error: demoError } = await signIn("test@me.com", "pass123")
+      const { error: demoError } = await signIn("fulltest@test.com", "tester_full")
       if (demoError) {
         setError(demoError.message || "Unable to start demo session")
       }
@@ -111,7 +111,7 @@ export default function LoginScreen() {
             }}
             disabled={loading}
           >
-            🎯 Demo Login (test@me.com)
+            🎯 Demo Login (fulltest@test.com)
           </button>
 
           <form onSubmit={handleEmailAuth} className="login-form">


### PR DESCRIPTION
## Summary
- update the demo login button to use the new fulltest@test.com credentials
- align the Supabase demo admin fallback with the new seeded account details

## Testing
- npm run dev -- --host 0.0.0.0 --port 4174

------
https://chatgpt.com/codex/tasks/task_e_68d720342b54832ebf9223d98c560414