### PR TITLE
Add session expiration safeguards

### DIFF
--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -1,0 +1,6 @@
+export const SESSION_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000
+
+export const hasSessionExpired = (timestamp, now = Date.now()) => {
+  if (!timestamp) return true
+  return now - timestamp > SESSION_MAX_AGE_MS
+}


### PR DESCRIPTION
## Summary
- persist a session timestamp for both demo and Supabase sign-ins and clear stale demo payloads
- expire stored sessions older than 14 days before hydrating auth state and surface logout when needed
- add a shared session timeout helper used by auth context and Supabase utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d728764c68832e9725def41ee52da9