### PR TITLE
Avoid redundant data fetches during auth transitions

### DIFF
--- a/src/screens/BudgetDetailsScreen.jsx
+++ b/src/screens/BudgetDetailsScreen.jsx
@@ -80,6 +80,7 @@ export default function BudgetDetailsScreen({
   budgets,
   setSelectedBudget,
   onMetadataChange,
+  onDataMutated,
 }) {
   const { userProfile } = useAuth()
   const planTier = userProfile?.plan_tier || userProfile?.planTier || "free"
@@ -303,6 +304,7 @@ export default function BudgetDetailsScreen({
           ...(metadata.changeLog || []),
         ],
       }))
+      onDataMutated?.()
     } finally {
       setLoading(false)
       setSnackbar(null)
@@ -344,6 +346,7 @@ export default function BudgetDetailsScreen({
           ...(metadata.changeLog || []),
         ],
       }))
+      onDataMutated?.()
       setSnackbar({
         message: "Allocations updated",
         actionLabel: "Undo",
@@ -720,6 +723,7 @@ export default function BudgetDetailsScreen({
 
       setBudgets(updatedBudgets)
       setSelectedBudget(updatedBudgets.find((b) => b.id === budget.id))
+      onDataMutated?.()
       setShowModal(false)
       setEditingTx(null)
     } catch (error) {
@@ -772,6 +776,7 @@ export default function BudgetDetailsScreen({
       })
 
       setBudgetNameDraft(trimmed)
+      onDataMutated?.()
     } catch (error) {
       console.error("Error updating budget name:", error)
       setBudgetNameDraft(budget.name || "")
@@ -1829,8 +1834,10 @@ BudgetDetailsScreen.propTypes = {
   ).isRequired,
   setSelectedBudget: PropTypes.func.isRequired,
   onMetadataChange: PropTypes.func,
+  onDataMutated: PropTypes.func,
 }
 
 BudgetDetailsScreen.defaultProps = {
   onMetadataChange: undefined,
+  onDataMutated: undefined,
 }

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -72,6 +72,7 @@ export default function BudgetsScreen({
   userId,
   onMetadataChange,
   onMetadataRemove,
+  onDataMutated,
 }) {
   const { userProfile } = useAuth()
   const planTier = userProfile?.plan_tier || userProfile?.planTier || "free"
@@ -160,6 +161,7 @@ export default function BudgetsScreen({
 
         setSelectedBudget({ ...newBudget, cycleMetadata })
         setViewMode("details")
+        onDataMutated?.()
       }
     } catch (error) {
       console.error("Error creating budget:", error)
@@ -200,6 +202,7 @@ export default function BudgetsScreen({
             ...(metadata.changeLog || []),
           ],
         }))
+        onDataMutated?.()
       }
     } catch (error) {
       console.error("Error updating budget:", error)
@@ -254,6 +257,7 @@ export default function BudgetsScreen({
             ...(metadata.changeLog || []),
           ],
         }))
+        onDataMutated?.()
       }
     } catch (error) {
       console.error("Error duplicating budget:", error)
@@ -274,6 +278,7 @@ export default function BudgetsScreen({
       } else {
         setBudgets((prev) => prev.filter((b) => b.id !== budgetId))
         onMetadataRemove?.(budgetId)
+        onDataMutated?.()
       }
     } catch (error) {
       console.error("Error deleting budget:", error)
@@ -726,9 +731,11 @@ BudgetsScreen.propTypes = {
   userId: PropTypes.string.isRequired,
   onMetadataChange: PropTypes.func,
   onMetadataRemove: PropTypes.func,
+  onDataMutated: PropTypes.func,
 }
 
 BudgetsScreen.defaultProps = {
   onMetadataChange: undefined,
   onMetadataRemove: undefined,
+  onDataMutated: undefined,
 }

--- a/src/screens/GoalsScreen.jsx
+++ b/src/screens/GoalsScreen.jsx
@@ -119,7 +119,7 @@ const getGoalMetrics = (goal) => {
   }
 }
 
-export default function GoalsScreen({ setViewMode, budgets = [], setBudgets }) {
+export default function GoalsScreen({ setViewMode, budgets = [], setBudgets, onDataMutated }) {
   const { user, userProfile } = useAuth()
   const planTier = userProfile?.plan_tier || userProfile?.planTier || "free"
   const planTierNormalized = String(planTier).toLowerCase()
@@ -421,6 +421,7 @@ export default function GoalsScreen({ setViewMode, budgets = [], setBudgets }) {
             : budget,
         ),
       )
+      onDataMutated?.()
     } catch (transactionUnexpected) {
       console.error("Unexpected error syncing contribution to budget:", transactionUnexpected)
     }
@@ -751,4 +752,9 @@ GoalsScreen.propTypes = {
     }),
   ),
   setBudgets: PropTypes.func.isRequired,
+  onDataMutated: PropTypes.func,
+}
+
+GoalsScreen.defaultProps = {
+  onDataMutated: undefined,
 }


### PR DESCRIPTION
## Summary
- track the last user id fetched so auth loading transitions don't reset the budgets/categories requests unnecessarily
- invalidate the cached user marker when categories update and expose an `onDataMutated` callback for budget/goal screens so new records trigger a future reload when needed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7298f9cf0832e8880facf1418ec6c