### PR TITLE
Add reports analytics and expand settings hub

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import BudgetDetailsScreen from "./screens/BudgetDetailsScreen"
 import CategoriesScreen from "./screens/CategoriesScreen"
 import GoalsScreen from "./screens/GoalsScreen"
 import AIInsightsScreen from "./screens/AIInsightsScreen"
+import ReportsScreen from "./screens/ReportsScreen"
 import SettingsScreen from "./screens/SettingsScreen"
 import LoadingScreen from "./components/LoadingScreen"
 import LoginScreen from "./screens/LoginScreen"
@@ -237,6 +238,21 @@ function AppContent() {
     [budgets, selectedBudget],
   )
 
+  const handleOpenAIInsights = useCallback(
+    (budgetId) => {
+      if (budgetId) {
+        const targetBudget = budgets.find((budget) => budget.id === budgetId)
+        if (targetBudget) {
+          setSelectedBudget(targetBudget)
+        }
+      } else if (!selectedBudget && budgets.length > 0) {
+        setSelectedBudget(budgets[0])
+      }
+      setViewMode("ai")
+    },
+    [budgets, selectedBudget, setSelectedBudget, setViewMode],
+  )
+
   useEffect(() => {
     if ((viewMode === "details" || viewMode === "ai") && !activeBudget) {
       if (budgets.length > 0) {
@@ -337,6 +353,10 @@ function AppContent() {
         />
       )}
 
+      {viewMode === "reports" && (
+        <ReportsScreen budgets={budgets} categories={categories} onViewInsights={handleOpenAIInsights} />
+      )}
+
       {viewMode === "ai" && activeBudget && <AIInsightsScreen budget={activeBudget} setViewMode={setViewMode} />}
 
       {viewMode === "ai" && !activeBudget && (
@@ -350,6 +370,7 @@ function AppContent() {
         <SettingsScreen
           user={user}
           categories={categories}
+          budgets={budgets}
           onManageCategories={() => setViewMode("categories")}
         />
       )}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -10,7 +10,7 @@ const NAV_ITEMS = [
 const keyToViewMode = {
   home: "budgets",
   goals: "goals",
-  reports: "ai",
+  reports: "reports",
   settings: "settings",
 }
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -216,8 +216,13 @@ export function AuthProvider({ children }) {
       loading,
       initializing,
       status,
+      refreshProfile: async () => {
+        if (!user) return null
+        return ensureProfile(user)
+      },
+      setUserProfile: applyProfile,
     }),
-    [user, userProfile, loading, initializing, status],
+    [user, userProfile, loading, initializing, status, ensureProfile, applyProfile],
   )
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>

--- a/src/lib/reporting.js
+++ b/src/lib/reporting.js
@@ -1,0 +1,286 @@
+const DAY_IN_MS = 24 * 60 * 60 * 1000
+
+const parseDate = (value) => {
+  if (!value) return null
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
+}
+
+const startOfDay = (date) => {
+  const result = new Date(date)
+  result.setHours(0, 0, 0, 0)
+  return result
+}
+
+const endOfDay = (date) => {
+  const result = new Date(date)
+  result.setHours(23, 59, 59, 999)
+  return result
+}
+
+export const flattenTransactions = (budgets = []) => {
+  return budgets.flatMap((budget) =>
+    (budget.transactions || []).map((transaction) => ({
+      ...transaction,
+      amount: Number.isFinite(transaction.amount) ? transaction.amount : Number.parseFloat(transaction.amount) || 0,
+      budgetId: budget.id,
+      budgetName: budget.name,
+    })),
+  )
+}
+
+export const getPeriodRange = (period = "week", referenceDate = new Date()) => {
+  const today = endOfDay(referenceDate)
+
+  if (period === "month") {
+    const start = new Date(today.getFullYear(), today.getMonth(), 1)
+    const end = endOfDay(new Date(today.getFullYear(), today.getMonth() + 1, 0))
+    const days = Math.max(1, Math.round((end - start) / DAY_IN_MS) + 1)
+    return {
+      period,
+      start,
+      end,
+      days,
+      label: start.toLocaleDateString(undefined, { month: "long", year: "numeric" }),
+    }
+  }
+
+  if (period === "custom") {
+    // Placeholder custom range (last 14 days)
+    const start = startOfDay(new Date(today.getTime() - 13 * DAY_IN_MS))
+    const end = today
+    return {
+      period,
+      start,
+      end,
+      days: 14,
+      label: "Last 14 days",
+    }
+  }
+
+  // Default to trailing 7 day window
+  const start = startOfDay(new Date(today.getTime() - 6 * DAY_IN_MS))
+  return {
+    period: "week",
+    start,
+    end: today,
+    days: 7,
+    label: "Last 7 days",
+  }
+}
+
+export const getPreviousRange = (range) => {
+  if (!range) return null
+  const { period, start, days } = range
+  if (period === "month") {
+    const startPrev = new Date(start.getFullYear(), start.getMonth() - 1, 1)
+    const endPrev = endOfDay(new Date(start.getFullYear(), start.getMonth(), 0))
+    const prevDays = Math.max(1, Math.round((endPrev - startPrev) / DAY_IN_MS) + 1)
+    return {
+      period,
+      start: startOfDay(startPrev),
+      end: endPrev,
+      days: prevDays,
+      label: startPrev.toLocaleDateString(undefined, { month: "long", year: "numeric" }),
+    }
+  }
+
+  const prevEnd = endOfDay(new Date(start.getTime() - 1))
+  const prevStart = startOfDay(new Date(prevEnd.getTime() - (days - 1) * DAY_IN_MS))
+  return {
+    period,
+    start: prevStart,
+    end: prevEnd,
+    days,
+    label: "Previous period",
+  }
+}
+
+export const filterTransactionsByRange = (transactions, range) => {
+  if (!range) return []
+  return transactions.filter((transaction) => {
+    const txDate = parseDate(transaction.date)
+    if (!txDate) return false
+    return txDate >= range.start && txDate <= range.end
+  })
+}
+
+export const sumByType = (transactions, type) => {
+  return transactions
+    .filter((tx) => tx.type === type)
+    .reduce((sum, tx) => sum + (Number.isFinite(tx.amount) ? tx.amount : 0), 0)
+}
+
+export const buildCategoryBreakdown = (transactions) => {
+  if (!transactions.length) return []
+  const totals = transactions.reduce((acc, tx) => {
+    const key = (tx.category || "Uncategorized").trim().toLowerCase()
+    const label = tx.category?.trim() || "Uncategorized"
+    const amount = Number.isFinite(tx.amount) ? tx.amount : 0
+    const entry = acc.get(key) || { key, label, amount: 0 }
+    entry.amount += amount
+    acc.set(key, entry)
+    return acc
+  }, new Map())
+
+  const aggregateTotal = Array.from(totals.values()).reduce((sum, entry) => sum + entry.amount, 0)
+  if (aggregateTotal <= 0) {
+    return Array.from(totals.values()).map((entry) => ({ ...entry, percent: 0 }))
+  }
+  return Array.from(totals.values())
+    .map((entry) => ({ ...entry, percent: (entry.amount / aggregateTotal) * 100 }))
+    .sort((a, b) => b.amount - a.amount)
+}
+
+const enumerateDays = (range) => {
+  const days = []
+  const cursor = new Date(range.start)
+  while (cursor <= range.end) {
+    days.push(new Date(cursor))
+    cursor.setDate(cursor.getDate() + 1)
+  }
+  return days
+}
+
+export const buildIncomeExpenseSeries = (transactions, range) => {
+  const days = enumerateDays(range)
+  return days.map((date) => {
+    const dayKey = date.toISOString().split("T")[0]
+    const totals = transactions.reduce(
+      (acc, tx) => {
+        const txDate = parseDate(tx.date)
+        if (!txDate) return acc
+        if (txDate.toISOString().split("T")[0] !== dayKey) return acc
+        const amount = Number.isFinite(tx.amount) ? tx.amount : 0
+        if (tx.type === "income") {
+          acc.income += amount
+        } else if (tx.type === "expense") {
+          acc.expense += amount
+        }
+        return acc
+      },
+      { income: 0, expense: 0 },
+    )
+    return {
+      date,
+      label: range.period === "month" ? date.getDate().toString() : date.toLocaleDateString(undefined, { weekday: "short" }),
+      ...totals,
+    }
+  })
+}
+
+export const calculateTrendComparisons = (transactions, range, previousRange) => {
+  if (!range || !previousRange) return []
+  const currentExpenses = buildCategoryBreakdown(
+    filterTransactionsByRange(transactions.filter((tx) => tx.type === "expense"), range),
+  )
+  const previousExpenses = buildCategoryBreakdown(
+    filterTransactionsByRange(transactions.filter((tx) => tx.type === "expense"), previousRange),
+  )
+
+  const previousLookup = new Map(previousExpenses.map((entry) => [entry.key, entry]))
+
+  return currentExpenses
+    .map((entry) => {
+      const previous = previousLookup.get(entry.key)
+      const previousAmount = previous?.amount ?? 0
+      const change = entry.amount - previousAmount
+      const percentChange = previousAmount > 0 ? (change / previousAmount) * 100 : entry.amount > 0 ? 100 : 0
+      return {
+        ...entry,
+        previousAmount,
+        change,
+        percentChange,
+      }
+    })
+    .filter((entry) => Number.isFinite(entry.percentChange))
+    .sort((a, b) => Math.abs(b.percentChange) - Math.abs(a.percentChange))
+}
+
+export const buildCashBurnSummary = (budgets, transactions, range) => {
+  const totalBudgeted = budgets.reduce((sum, budget) => {
+    return (
+      sum +
+      (budget.categoryBudgets || []).reduce((inner, category) => inner + (Number(category.budgetedAmount) || 0), 0)
+    )
+  }, 0)
+
+  const expensesThisPeriod = filterTransactionsByRange(
+    transactions.filter((tx) => tx.type === "expense"),
+    range,
+  )
+  const spent = expensesThisPeriod.reduce((sum, tx) => sum + (Number.isFinite(tx.amount) ? tx.amount : 0), 0)
+  const avgDailySpend = range.days > 0 ? spent / range.days : 0
+  const remaining = Math.max(0, totalBudgeted - spent)
+  const projectedDaysLeft = avgDailySpend > 0 ? remaining / avgDailySpend : null
+  const progress = totalBudgeted > 0 ? Math.min(1, spent / totalBudgeted) : 0
+
+  return {
+    totalBudgeted,
+    spent,
+    remaining,
+    avgDailySpend,
+    projectedDaysLeft,
+    progress,
+  }
+}
+
+export const summarizeReport = (budgets, period = "week", referenceDate = new Date()) => {
+  const allTransactions = flattenTransactions(budgets)
+  const range = getPeriodRange(period, referenceDate)
+  const previousRange = getPreviousRange(range)
+  const scopedTransactions = filterTransactionsByRange(allTransactions, range)
+  const totalIncome = sumByType(scopedTransactions, "income")
+  const totalExpenses = sumByType(scopedTransactions, "expense")
+  const avgDailySpend = range.days > 0 ? totalExpenses / range.days : 0
+  const balance = totalIncome - totalExpenses
+
+  const categoryBreakdown = buildCategoryBreakdown(scopedTransactions.filter((tx) => tx.type === "expense"))
+  const incomeExpenseSeries = buildIncomeExpenseSeries(scopedTransactions, range)
+  const trends = calculateTrendComparisons(allTransactions, range, previousRange)
+  const cashBurn = buildCashBurnSummary(budgets, allTransactions, getPeriodRange("month", referenceDate))
+
+  return {
+    range,
+    previousRange,
+    totalIncome,
+    totalExpenses,
+    avgDailySpend,
+    balance,
+    categoryBreakdown,
+    incomeExpenseSeries,
+    cashBurn,
+    trends,
+  }
+}
+
+export const formatCurrency = (value, currency = "USD") => {
+  try {
+    return new Intl.NumberFormat(undefined, { style: "currency", currency }).format(Number.isFinite(value) ? value : 0)
+  } catch (error) {
+    return `$${Number(value || 0).toFixed(2)}`
+  }
+}
+
+export const formatPercent = (value) => {
+  if (!Number.isFinite(value)) return "0%"
+  return `${value > 0 ? "+" : ""}${value.toFixed(1)}%`
+}
+
+export const abbreviateCurrency = (value, currency = "USD") => {
+  if (!Number.isFinite(value)) {
+    return formatCurrency(0, currency)
+  }
+  const absValue = Math.abs(value)
+  if (absValue >= 1_000_000_000) {
+    return `${value < 0 ? "-" : ""}${formatCurrency(absValue / 1_000_000_000, currency)}B`
+  }
+  if (absValue >= 1_000_000) {
+    return `${value < 0 ? "-" : ""}${formatCurrency(absValue / 1_000_000, currency)}M`
+  }
+  if (absValue >= 1_000) {
+    return `${value < 0 ? "-" : ""}${formatCurrency(absValue / 1_000, currency)}K`
+  }
+  return formatCurrency(value, currency)
+}
+

--- a/src/lib/supabase-mock.js
+++ b/src/lib/supabase-mock.js
@@ -302,6 +302,17 @@ export const getUserProfile = async (userId) => {
   return { data: profile, error: profile ? null : { code: "PGRST116" } }
 }
 
+export const updateUserProfile = async (userId, updates) => {
+  await delay()
+  const existing = JSON.parse(localStorage.getItem(`user_profiles_${userId}`) || "null")
+  if (!existing) {
+    return { data: null, error: { message: "Profile not found" } }
+  }
+  const merged = { ...existing, ...updates, updated_at: new Date().toISOString() }
+  localStorage.setItem(`user_profiles_${userId}`, JSON.stringify(merged))
+  return { data: merged, error: null }
+}
+
 export const getBudgets = async (userId) => {
   await delay()
   const budgets = JSON.parse(localStorage.getItem(`budgets_${userId}`) || "[]")
@@ -415,4 +426,17 @@ export const updateUserCategories = async (userId, categories) => {
   const categoryData = { user_id: userId, categories }
   localStorage.setItem(`user_categories_${userId}`, JSON.stringify(categoryData))
   return { data: [categoryData], error: null }
+}
+
+export const getLatestAIInsight = async (userId) => {
+  await delay()
+  if (!userId) {
+    return { data: null, error: null }
+  }
+  const insights = JSON.parse(localStorage.getItem(`ai_insights_${userId}`) || "[]")
+  if (!Array.isArray(insights) || insights.length === 0) {
+    return { data: null, error: null }
+  }
+  const sorted = [...insights].sort((a, b) => new Date(b.created_at) - new Date(a.created_at))
+  return { data: sorted[0], error: null }
 }

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -95,6 +95,26 @@ export const getUserProfile = async (userId) => {
   return supabase.from("user_profiles").select("*").eq("id", userId).single()
 }
 
+export const updateUserProfile = async (userId, updates) => {
+  if (!userId) {
+    return { data: null, error: { message: "User ID is required" } }
+  }
+
+  const payload = {
+    ...updates,
+    updated_at: new Date().toISOString(),
+  }
+
+  const { data, error } = await supabase
+    .from("user_profiles")
+    .update(payload)
+    .eq("id", userId)
+    .select("*")
+    .single()
+
+  return { data, error }
+}
+
 const normalizeTransactionRecord = (transaction) => ({
   ...transaction,
   amount: Number(transaction.amount || 0),
@@ -405,6 +425,26 @@ export const getAIInsights = async (userId, budgetId, options = {}) => {
 
   const { data, error } = await query
   return { data: (data || []).map(normalizeInsightRecord), error }
+}
+
+export const getLatestAIInsight = async (userId) => {
+  if (!userId) {
+    return { data: null, error: null }
+  }
+
+  const { data, error } = await supabase
+    .from("ai_insights")
+    .select("*")
+    .eq("user_id", userId)
+    .order("created_at", { ascending: false })
+    .limit(1)
+
+  if (error) {
+    return { data: null, error }
+  }
+
+  const record = Array.isArray(data) ? data[0] : data
+  return { data: record ? normalizeInsightRecord(record) : null, error: null }
 }
 
 export const generateAIInsight = async ({ userId, budgetId, metrics = {} }) => {

--- a/src/screens/ReportsScreen.jsx
+++ b/src/screens/ReportsScreen.jsx
@@ -1,0 +1,422 @@
+import { useEffect, useMemo, useState } from "react"
+import PropTypes from "prop-types"
+import { useAuth } from "../contexts/AuthContext"
+import { abbreviateCurrency, formatCurrency, summarizeReport, getPeriodRange, flattenTransactions } from "../lib/reporting"
+import { getLatestAIInsight } from "../lib/supabase"
+
+const PERIOD_OPTIONS = [
+  { value: "week", label: "Week" },
+  { value: "month", label: "Month" },
+  { value: "custom", label: "Custom" },
+]
+
+const COLOR_PALETTE = ["#5B8DEF", "#3ED1B7", "#FF9F43", "#FF6B6B", "#9D7DFF", "#54D3FF", "#FFB8D2"]
+
+const getCategoryIcon = (categoryName, categories) => {
+  if (!categoryName) return "💸"
+  const key = categoryName.trim().toLowerCase()
+  const collections = [categories?.expense || [], categories?.income || []]
+  for (const collection of collections) {
+    const match = collection.find((category) => category.name?.trim().toLowerCase() === key)
+    if (match?.icon) return match.icon
+  }
+  return "💸"
+}
+
+const buildPieBackground = (breakdown) => {
+  if (!breakdown?.length) return "conic-gradient(#E5E7EB 0deg 360deg)"
+  let start = 0
+  const segments = breakdown.map((entry, index) => {
+    const sweep = (entry.percent / 100) * 360
+    const end = start + sweep
+    const color = COLOR_PALETTE[index % COLOR_PALETTE.length]
+    const segment = `${color} ${start}deg ${end}deg`
+    start = end
+    return segment
+  })
+  return `conic-gradient(${segments.join(", ")})`
+}
+
+const buildLinePath = (series, key, width, height) => {
+  if (!series?.length) return ""
+  const maxValue = Math.max(
+    1,
+    ...series.map((point) => Math.max(0, Number.isFinite(point[key]) ? point[key] : 0)),
+  )
+  const step = series.length > 1 ? width / (series.length - 1) : width
+  return series
+    .map((point, index) => {
+      const x = Math.round(index * step)
+      const value = Number.isFinite(point[key]) ? Math.max(0, point[key]) : 0
+      const normalized = value / maxValue
+      const y = Math.round(height - normalized * height)
+      return `${x},${y}`
+    })
+    .join(" ")
+}
+
+const buildChartLabels = (series) => {
+  if (!series?.length) return []
+  const step = Math.max(1, Math.floor(series.length / 6))
+  return series.map((point, index) => ({ label: point.label, index })).filter((item, idx) => idx % step === 0)
+}
+
+export default function ReportsScreen({ budgets, categories, onViewInsights }) {
+  const { userProfile, user } = useAuth()
+  const [period, setPeriod] = useState("week")
+  const [chartPeriod, setChartPeriod] = useState("week")
+  const [insightPreview, setInsightPreview] = useState(null)
+  const [aiLoading, setAiLoading] = useState(false)
+  const [aiError, setAiError] = useState(null)
+
+  const currency = userProfile?.preferences?.currency || "USD"
+
+  const report = useMemo(() => summarizeReport(budgets, period), [budgets, period])
+  const chartSeries = useMemo(() => {
+    if (chartPeriod === period) {
+      return report.incomeExpenseSeries
+    }
+    const scoped = summarizeReport(budgets, chartPeriod)
+    return scoped.incomeExpenseSeries
+  }, [budgets, chartPeriod, period, report.incomeExpenseSeries])
+
+  const chartRange = useMemo(() => getPeriodRange(chartPeriod), [chartPeriod])
+  const transactions = useMemo(() => flattenTransactions(budgets), [budgets])
+
+  useEffect(() => {
+    if (!user?.id) return
+    let isActive = true
+    setAiLoading(true)
+    setAiError(null)
+
+    const loadLatest = async () => {
+      try {
+        const { data, error } = await getLatestAIInsight(user.id)
+        if (!isActive) return
+        if (error) {
+          console.error("Failed to load AI insights", error)
+          setAiError(error.message || "Unable to load insights")
+          setInsightPreview(null)
+          return
+        }
+        setInsightPreview(data || null)
+      } catch (insightError) {
+        if (!isActive) return
+        console.error("Unexpected AI insight error", insightError)
+        setAiError(insightError.message || "Unable to load insights")
+        setInsightPreview(null)
+      } finally {
+        if (isActive) {
+          setAiLoading(false)
+        }
+      }
+    }
+
+    loadLatest()
+
+    return () => {
+      isActive = false
+    }
+  }, [user?.id])
+
+  useEffect(() => {
+    setChartPeriod(period)
+  }, [period])
+
+  const handleViewInsights = () => {
+    if (!insightPreview) {
+      onViewInsights?.(null)
+      return
+    }
+    onViewInsights?.(insightPreview.budget_id || null)
+  }
+
+  const breakdown = report.categoryBreakdown
+  const cashBurn = report.cashBurn
+  const trends = report.trends.slice(0, 3)
+
+  const chartWidth = 360
+  const chartHeight = 160
+  const incomePath = buildLinePath(chartSeries, "income", chartWidth, chartHeight)
+  const expensePath = buildLinePath(chartSeries, "expense", chartWidth, chartHeight)
+  const chartLabels = buildChartLabels(chartSeries)
+
+  const aiSummary = insightPreview?.insights?.summary
+  const aiBudgetName = useMemo(() => {
+    if (!insightPreview?.budget_id) return null
+    const budget = budgets.find((entry) => entry.id === insightPreview.budget_id)
+    return budget?.name || insightPreview.budget_id
+  }, [budgets, insightPreview?.budget_id])
+
+  const trendStatements = trends.length
+    ? trends.map((entry) => {
+        const direction = entry.percentChange < 0 ? "less" : "more"
+        const absolute = Math.abs(entry.percentChange)
+        const formatted = Number.isFinite(absolute) ? absolute.toFixed(1) : "0"
+        return `You spent ${formatted}% ${direction} on ${entry.label}.`
+      })
+    : ["We need a bit more data to highlight category trends. Keep logging transactions!"]
+
+  const upcomingRangeLabel = report.range?.label || ""
+
+  const totalTransactions = transactions.length
+
+  return (
+    <div className="reports-screen">
+      <header className="reports-header">
+        <div>
+          <h1>Reports</h1>
+          <p className="reports-subtitle">
+            Explore spending patterns, cash burn, and income trends for {upcomingRangeLabel.toLowerCase()}.
+          </p>
+        </div>
+        <label className="reports-period-select">
+          <span className="sr-only">Select reporting period</span>
+          <select value={period} onChange={(event) => setPeriod(event.target.value)}>
+            {PERIOD_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </header>
+
+      {totalTransactions === 0 && (
+        <div className="report-empty">
+          <p>
+            We&apos;ll start charting insights as soon as you add transactions to your budgets. Create a budget and begin
+            tracking spending to unlock detailed analytics.
+          </p>
+        </div>
+      )}
+
+      <section className="report-grid">
+        <article className="report-card">
+          <header>
+            <h2>Average Daily Spend</h2>
+            <span className="metric-tag">{report.range?.label}</span>
+          </header>
+          <p className="metric-value">{formatCurrency(report.avgDailySpend, currency)}</p>
+          <p className="metric-subtext">Across all logged expenses</p>
+        </article>
+
+        <article className="report-card">
+          <header>
+            <h2>Total Expenses</h2>
+            <span className="metric-tag">{report.range?.label}</span>
+          </header>
+          <p className="metric-value expense">{abbreviateCurrency(report.totalExpenses, currency)}</p>
+          <p className="metric-subtext">
+            Income: <strong>{abbreviateCurrency(report.totalIncome, currency)}</strong>
+          </p>
+        </article>
+
+        <article className="report-card">
+          <header>
+            <h2>Net Balance</h2>
+            <span className={`metric-tag ${report.balance >= 0 ? "success" : "warning"}`}>
+              {report.balance >= 0 ? "Surplus" : "Deficit"}
+            </span>
+          </header>
+          <p className={`metric-value ${report.balance >= 0 ? "income" : "expense"}`}>
+            {abbreviateCurrency(report.balance, currency)}
+          </p>
+          <p className="metric-subtext">
+            {report.balance >= 0 ? "Great job staying ahead" : "Review discretionary categories"}
+          </p>
+        </article>
+      </section>
+
+      <section className="report-card cash-burn-card">
+        <header>
+          <div>
+            <h2>Cash Burn</h2>
+            <p className="metric-subtext">Monitoring current month budgets</p>
+          </div>
+          <span className="metric-tag accent">{cashBurn.projectedDaysLeft ? `${Math.floor(cashBurn.projectedDaysLeft)} days left` : "Stable"}</span>
+        </header>
+        <div className="cash-burn-body">
+          <div className="cash-burn-number">{formatCurrency(cashBurn.avgDailySpend, currency)}</div>
+          <div className="cash-burn-label">Average daily spend</div>
+          <div className="progress-bar">
+            <div className="progress-bar__track" aria-hidden="true">
+              <div
+                className="progress-bar__fill"
+                style={{ width: `${Math.min(100, Math.round((cashBurn.progress || 0) * 100))}%` }}
+              />
+            </div>
+            <div className="progress-bar__legend">
+              <span>Spent {formatCurrency(cashBurn.spent, currency)}</span>
+              <span>Budgeted {formatCurrency(cashBurn.totalBudgeted, currency)}</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="report-card category-card">
+        <header>
+          <h2>Category Breakdown</h2>
+          <p className="metric-subtext">Expense mix for {report.range?.label}</p>
+        </header>
+        <div className="category-content">
+          <div className="category-pie" style={{ background: buildPieBackground(breakdown) }} aria-hidden="true" />
+          <ul className="category-list">
+            {breakdown.length ? (
+              breakdown.map((entry, index) => (
+                <li key={entry.key}>
+                  <span className="category-icon" aria-hidden="true">
+                    {getCategoryIcon(entry.label, categories)}
+                  </span>
+                  <div className="category-info">
+                    <span className="category-name">{entry.label}</span>
+                    <span className="category-amount">{formatCurrency(entry.amount, currency)}</span>
+                  </div>
+                  <span className="category-percent">{entry.percent.toFixed(1)}%</span>
+                  <span
+                    className="category-color"
+                    aria-hidden="true"
+                    style={{ backgroundColor: COLOR_PALETTE[index % COLOR_PALETTE.length] }}
+                  />
+                </li>
+              ))
+            ) : (
+              <li className="category-empty">Log expenses to populate category analytics.</li>
+            )}
+          </ul>
+        </div>
+      </section>
+
+      <section className="report-card chart-card">
+        <header className="chart-header">
+          <div>
+            <h2>Income vs Expenses</h2>
+            <p className="metric-subtext">Daily totals ({chartRange.label.toLowerCase()})</p>
+          </div>
+          <div className="chart-toggle" role="group" aria-label="Select chart period">
+            {PERIOD_OPTIONS.filter((option) => option.value !== "custom").map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                className={chartPeriod === option.value ? "is-active" : ""}
+                onClick={() => setChartPeriod(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </header>
+        <div className="chart-wrapper" role="img" aria-label="Line chart comparing income and expenses">
+          {chartSeries.length ? (
+            <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} preserveAspectRatio="none">
+              <polyline points={incomePath} fill="none" stroke="#3ED1B7" strokeWidth="3" />
+              <polyline points={expensePath} fill="none" stroke="#FF6B6B" strokeWidth="3" />
+            </svg>
+          ) : (
+            <div className="chart-empty">Add income and expenses to unlock the comparison chart.</div>
+          )}
+        </div>
+        {chartSeries.length > 0 && (
+          <div className="chart-legend">
+            <span>
+              <span className="legend-dot" style={{ backgroundColor: "#3ED1B7" }} /> Income
+            </span>
+            <span>
+              <span className="legend-dot" style={{ backgroundColor: "#FF6B6B" }} /> Expenses
+            </span>
+          </div>
+        )}
+        {chartSeries.length > 0 && (
+          <div className="chart-axis">
+            {chartLabels.map((label) => (
+              <span key={`${label.label}-${label.index}`}>{label.label}</span>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="report-card trends-card">
+        <header>
+          <h2>Trends &amp; Insights</h2>
+          <p className="metric-subtext">Week-over-week category shifts</p>
+        </header>
+        <ul className="trends-list">
+          {trendStatements.map((statement, index) => (
+            <li key={statement} className={index === 0 ? "highlight" : ""}>
+              <span className="trend-icon" aria-hidden="true">
+                {index === 0 ? "📈" : "🧭"}
+              </span>
+              <span>{statement}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="report-card ai-card">
+        <header>
+          <div>
+            <h2>
+              <span aria-hidden="true" className="ai-icon">
+                ⚡
+              </span>
+              AI Insights Preview
+            </h2>
+            <p className="metric-subtext">Latest recommendations generated for your budgets</p>
+          </div>
+        </header>
+        <div className="ai-body">
+          {aiLoading ? (
+            <p className="ai-status">Gathering the latest insight...</p>
+          ) : aiError ? (
+            <p className="ai-status error">{aiError}</p>
+          ) : insightPreview ? (
+            <>
+              {aiBudgetName && <p className="ai-budget">{aiBudgetName}</p>}
+              <p className="ai-summary">{aiSummary || "Your AI co-pilot is ready with fresh guidance."}</p>
+            </>
+          ) : (
+            <p className="ai-status">Generate an AI report from any budget to see a personalized preview here.</p>
+          )}
+          <button type="button" className="primary-button" onClick={handleViewInsights} disabled={aiLoading}>
+            View Full AI Insights
+          </button>
+        </div>
+      </section>
+    </div>
+  )
+}
+
+ReportsScreen.propTypes = {
+  budgets: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      name: PropTypes.string,
+      transactions: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+          amount: PropTypes.number,
+          category: PropTypes.string,
+          type: PropTypes.string,
+          date: PropTypes.string,
+        }),
+      ),
+      categoryBudgets: PropTypes.arrayOf(
+        PropTypes.shape({
+          category: PropTypes.string,
+          budgetedAmount: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+        }),
+      ),
+    }),
+  ),
+  categories: PropTypes.shape({
+    income: PropTypes.array,
+    expense: PropTypes.array,
+  }),
+  onViewInsights: PropTypes.func,
+}
+
+ReportsScreen.defaultProps = {
+  budgets: [],
+  categories: { income: [], expense: [] },
+  onViewInsights: undefined,
+}

--- a/src/screens/SettingsScreen.jsx
+++ b/src/screens/SettingsScreen.jsx
@@ -1,13 +1,250 @@
+import { useEffect, useMemo, useState } from "react"
 import PropTypes from "prop-types"
-import { signOut } from "../lib/supabase"
+import { signOut, updateUserProfile } from "../lib/supabase"
 import { useAuth } from "../contexts/AuthContext"
 
-export default function SettingsScreen({ user, categories, onManageCategories }) {
-  const { userProfile } = useAuth()
+const THEME_STORAGE_KEY = "pb:theme-preference"
+
+const resolveSystemTheme = () => {
+  if (typeof window === "undefined") return "light"
+  return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+}
+
+const useThemePreference = () => {
+  const [preference, setPreference] = useState(() => {
+    if (typeof window === "undefined") return "system"
+    return localStorage.getItem(THEME_STORAGE_KEY) || "system"
+  })
+  const [systemTheme, setSystemTheme] = useState(resolveSystemTheme)
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return undefined
+    const media = window.matchMedia("(prefers-color-scheme: dark)")
+    const handleChange = (event) => setSystemTheme(event.matches ? "dark" : "light")
+    if (media.addEventListener) {
+      media.addEventListener("change", handleChange)
+    } else if (media.addListener) {
+      media.addListener(handleChange)
+    }
+    return () => {
+      if (media.removeEventListener) {
+        media.removeEventListener("change", handleChange)
+      } else if (media.removeListener) {
+        media.removeListener(handleChange)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    if (preference === "system") {
+      localStorage.removeItem(THEME_STORAGE_KEY)
+    } else {
+      localStorage.setItem(THEME_STORAGE_KEY, preference)
+    }
+  }, [preference])
+
+  useEffect(() => {
+    if (typeof document === "undefined") return
+    const effectiveTheme = preference === "system" ? systemTheme : preference
+    document.documentElement.dataset.theme = effectiveTheme
+  }, [preference, systemTheme])
+
+  return {
+    preference,
+    systemTheme,
+    effectiveTheme: preference === "system" ? systemTheme : preference,
+    setThemePreference: setPreference,
+    resetToSystem: () => setPreference("system"),
+  }
+}
+
+const DEFAULT_PREFERENCES = {
+  budgetStyle: "zero-based",
+  currency: "USD",
+  notifications: {
+    weeklyReports: true,
+    aiNudges: true,
+  },
+}
+
+const formatInitials = (name, email) => {
+  if (name?.trim()) {
+    const segments = name.trim().split(" ")
+    return segments
+      .slice(0, 2)
+      .map((segment) => segment.charAt(0).toUpperCase())
+      .join("")
+  }
+  if (email) {
+    return email.charAt(0).toUpperCase()
+  }
+  return "U"
+}
+
+const mergePreferences = (profilePreferences) => {
+  if (!profilePreferences) return DEFAULT_PREFERENCES
+  return {
+    ...DEFAULT_PREFERENCES,
+    ...profilePreferences,
+    notifications: {
+      ...DEFAULT_PREFERENCES.notifications,
+      ...(profilePreferences.notifications || {}),
+    },
+  }
+}
+
+const currencyOptions = ["USD", "EUR", "GBP", "AUD", "CAD", "JPY", "INR"]
+
+export default function SettingsScreen({ user, categories, budgets, onManageCategories }) {
+  const { userProfile, refreshProfile, setUserProfile } = useAuth()
+  const [editOpen, setEditOpen] = useState(false)
+  const [profileDraft, setProfileDraft] = useState({ name: "", email: "" })
+  const [profileStatus, setProfileStatus] = useState(null)
+  const [preferencesState, setPreferencesState] = useState(DEFAULT_PREFERENCES)
+  const [preferencesStatus, setPreferencesStatus] = useState(null)
+  const [preferencesError, setPreferencesError] = useState(null)
+  const [utilityStatus, setUtilityStatus] = useState(null)
+  const [utilityLoading, setUtilityLoading] = useState(false)
+  const { preference, effectiveTheme, setThemePreference, resetToSystem } = useThemePreference()
+
+  useEffect(() => {
+    setProfileDraft({
+      name: userProfile?.full_name || "",
+      email: userProfile?.email || user?.email || "",
+    })
+  }, [user?.email, userProfile?.email, userProfile?.full_name])
+
+  useEffect(() => {
+    setPreferencesState(mergePreferences(userProfile?.preferences))
+  }, [userProfile?.preferences])
 
   const handleSignOut = async () => {
     if (confirm("Are you sure you want to sign out?")) {
       await signOut()
+    }
+  }
+
+  const tier = useMemo(() => {
+    const candidate = userProfile?.tier || userProfile?.subscription_tier
+    if (!candidate) return "Free"
+    return candidate.charAt(0).toUpperCase() + candidate.slice(1)
+  }, [userProfile?.subscription_tier, userProfile?.tier])
+
+  const preferencesDirty = useMemo(() => preferencesStatus === "saving", [preferencesStatus])
+
+  const updatePreferences = async (updater) => {
+    if (!user?.id) return
+    setPreferencesStatus("saving")
+    setPreferencesError(null)
+    setUtilityStatus(null)
+    const nextPreferences = typeof updater === "function" ? updater(preferencesState) : updater
+    setPreferencesState(nextPreferences)
+    try {
+      const { data, error } = await updateUserProfile(user.id, { preferences: nextPreferences })
+      if (error) {
+        setPreferencesError(error.message || "Unable to save preferences")
+        setPreferencesStatus("error")
+        return
+      }
+      if (data) {
+        setUserProfile?.(data)
+      } else {
+        await refreshProfile?.()
+      }
+      setPreferencesStatus("saved")
+    } catch (error) {
+      console.error("Failed to update preferences", error)
+      setPreferencesError(error.message || "Unexpected error saving preferences")
+      setPreferencesStatus("error")
+    }
+  }
+
+  const handleProfileSubmit = async (event) => {
+    event.preventDefault()
+    if (!user?.id) return
+    setProfileStatus("saving")
+    try {
+      const { data, error } = await updateUserProfile(user.id, {
+        full_name: profileDraft.name,
+        email: profileDraft.email,
+      })
+      if (error) {
+        setProfileStatus(error.message || "Unable to update profile")
+        return
+      }
+      if (data) {
+        setUserProfile?.(data)
+      } else {
+        await refreshProfile?.()
+      }
+      setProfileStatus("Profile updated")
+      setEditOpen(false)
+    } catch (error) {
+      console.error("Failed to update profile", error)
+      setProfileStatus(error.message || "Unexpected error updating profile")
+    }
+  }
+
+  const handleThemeToggle = () => {
+    if (preference === "system") {
+      setThemePreference(effectiveTheme === "dark" ? "light" : "dark")
+      return
+    }
+    setThemePreference(effectiveTheme === "dark" ? "light" : "dark")
+  }
+
+  const handleExportData = () => {
+    const exportPayload = {
+      exportedAt: new Date().toISOString(),
+      user: {
+        id: user?.id,
+        email: user?.email,
+      },
+      profile: userProfile,
+      categories,
+      budgets: (budgets || []).map((budget) => ({
+        id: budget.id,
+        name: budget.name,
+        categoryBudgets: budget.categoryBudgets,
+        transactions: budget.transactions,
+      })),
+    }
+
+    const blob = new Blob([JSON.stringify(exportPayload, null, 2)], { type: "application/json" })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = `pocket-budget-export-${new Date().toISOString().split("T")[0]}.json`
+    anchor.click()
+    URL.revokeObjectURL(url)
+    setUtilityStatus("Data exported successfully")
+  }
+
+  const handleClearCache = async () => {
+    if (typeof window === "undefined") return
+    setUtilityLoading(true)
+    setUtilityStatus(null)
+    try {
+      const keysToRemove = []
+      for (let i = 0; i < localStorage.length; i += 1) {
+        const key = localStorage.key(i)
+        if (!key) continue
+        if (key.startsWith("pb:") || key.includes("budgets_") || key.includes("transactions_") || key.includes("mock")) {
+          keysToRemove.push(key)
+        }
+      }
+      keysToRemove.forEach((key) => localStorage.removeItem(key))
+      if (window.caches) {
+        const cacheKeys = await window.caches.keys()
+        await Promise.all(cacheKeys.map((cacheKey) => window.caches.delete(cacheKey)))
+      }
+      setUtilityStatus("Local cache cleared")
+    } catch (error) {
+      console.error("Failed to clear cache", error)
+      setUtilityStatus(error.message || "Unable to clear cache")
+    } finally {
+      setUtilityLoading(false)
     }
   }
 
@@ -17,13 +254,173 @@ export default function SettingsScreen({ user, categories, onManageCategories })
   return (
     <div className="settings-screen">
       <section className="settings-section">
-        <h2>Account</h2>
-        <div className="settings-card">
-          <p className="settings-name">{userProfile?.full_name || user?.email}</p>
-          <p className="settings-email">{user?.email}</p>
-          <button type="button" className="secondary-button" onClick={handleSignOut}>
-            Sign out
+        <h2>Profile &amp; Account</h2>
+        <div className="settings-card profile-card">
+          <div className="profile-header">
+            <div className="avatar" aria-hidden="true">
+              {formatInitials(userProfile?.full_name, user?.email)}
+            </div>
+            <div>
+              <p className="settings-name">{userProfile?.full_name || user?.email}</p>
+              <p className="settings-email">{userProfile?.email || user?.email}</p>
+            </div>
+          </div>
+          <div className="profile-actions">
+            <button type="button" className="secondary-button" onClick={() => setEditOpen(true)}>
+              Edit profile
+            </button>
+            <button type="button" className="link-button" onClick={handleSignOut}>
+              Log out
+            </button>
+          </div>
+          {typeof profileStatus === "string" && profileStatus !== "saving" && (
+            <p className="status-text">{profileStatus}</p>
+          )}
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <h2>Subscription &amp; Billing</h2>
+        <div className="settings-card subscription-card">
+          <div>
+            <p className="subscription-tier">Current plan: {tier}</p>
+            <p className="settings-description">
+              Unlock unlimited AI reports, sharing, and premium widgets with Pocket Budget Pro.
+            </p>
+          </div>
+          <button type="button" className="primary-button">
+            {tier.toLowerCase() === "pro" ? "Manage plan" : "Upgrade to Pro"}
           </button>
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <h2>Preferences</h2>
+        <div className="settings-card">
+          <div className="settings-row">
+            <div>
+              <h3>Budget style</h3>
+              <p className="settings-description">Choose how Pocket Budget frames your envelopes.</p>
+            </div>
+            <div className="segmented-control" role="group" aria-label="Budget style">
+              {[
+                { value: "zero-based", label: "Zero-based" },
+                { value: "envelope", label: "Envelope" },
+              ].map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={preferencesState.budgetStyle === option.value ? "is-active" : ""}
+                  onClick={() => updatePreferences((prev) => ({ ...prev, budgetStyle: option.value }))}
+                  disabled={preferencesDirty}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="settings-row">
+            <div>
+              <h3>Currency</h3>
+              <p className="settings-description">Display budgets and reports in your preferred currency.</p>
+            </div>
+            <select
+              value={preferencesState.currency}
+              onChange={(event) => updatePreferences((prev) => ({ ...prev, currency: event.target.value }))}
+              disabled={preferencesDirty}
+            >
+              {currencyOptions.map((code) => (
+                <option key={code} value={code}>
+                  {code}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="settings-row">
+            <div>
+              <h3>Notifications</h3>
+              <p className="settings-description">Stay on top of weekly digests and AI nudges.</p>
+            </div>
+            <div className="toggle-group">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={Boolean(preferencesState.notifications.weeklyReports)}
+                  onChange={(event) =>
+                    updatePreferences((prev) => ({
+                      ...prev,
+                      notifications: {
+                        ...prev.notifications,
+                        weeklyReports: event.target.checked,
+                      },
+                    }))
+                  }
+                />
+                Weekly reports
+              </label>
+              <label>
+                <input
+                  type="checkbox"
+                  checked={Boolean(preferencesState.notifications.aiNudges)}
+                  onChange={(event) =>
+                    updatePreferences((prev) => ({
+                      ...prev,
+                      notifications: {
+                        ...prev.notifications,
+                        aiNudges: event.target.checked,
+                      },
+                    }))
+                  }
+                />
+                AI nudges
+              </label>
+            </div>
+          </div>
+          {preferencesStatus === "saved" && <p className="status-text">Preferences saved</p>}
+          {preferencesStatus === "error" && <p className="status-text error">{preferencesError}</p>}
+        </div>
+      </section>
+
+      <section className="settings-section">
+        <h2>App Settings</h2>
+        <div className="settings-card">
+          <div className="settings-row">
+            <div>
+              <h3>Dark mode</h3>
+              <p className="settings-description">Pocket Budget follows your system theme automatically.</p>
+            </div>
+            <div className="theme-toggle">
+              <button type="button" className={effectiveTheme === "dark" ? "is-active" : ""} onClick={handleThemeToggle}>
+                {effectiveTheme === "dark" ? "Dark" : "Light"}
+              </button>
+              <button type="button" className="link-button" onClick={resetToSystem}>
+                Use system default
+              </button>
+            </div>
+          </div>
+
+          <div className="settings-row">
+            <div>
+              <h3>Export data</h3>
+              <p className="settings-description">Download a copy of your budgets and transaction history.</p>
+            </div>
+            <button type="button" className="secondary-button" onClick={handleExportData}>
+              Export JSON
+            </button>
+          </div>
+
+          <div className="settings-row">
+            <div>
+              <h3>Clear cache</h3>
+              <p className="settings-description">Remove stored sessions and offline data.</p>
+            </div>
+            <button type="button" className="link-button" onClick={handleClearCache} disabled={utilityLoading}>
+              {utilityLoading ? "Clearing…" : "Clear cache"}
+            </button>
+          </div>
+          {utilityStatus && <p className="status-text">{utilityStatus}</p>}
         </div>
       </section>
 
@@ -41,30 +438,80 @@ export default function SettingsScreen({ user, categories, onManageCategories })
 
       <section className="settings-section">
         <h2>About Pocket Budget</h2>
-        <div className="settings-card">
-          <p>Version 1.0 — all features are unlocked for every account.</p>
+        <div className="settings-card about-card">
+          <p>Version 1.0.0</p>
           <p>
-            Need help or have feedback? Reach out at <a href="mailto:support@pocketbudget.app">support@pocketbudget.app</a>.
+            <a href="https://pocketbudget.app/privacy" target="_blank" rel="noreferrer">
+              Privacy Policy
+            </a>
+            <span aria-hidden="true"> · </span>
+            <a href="https://pocketbudget.app/terms" target="_blank" rel="noreferrer">
+              Terms of Service
+            </a>
           </p>
         </div>
       </section>
+
+      {editOpen && (
+        <div className="modal-backdrop" role="dialog" aria-modal="true">
+          <form className="modal" onSubmit={handleProfileSubmit}>
+            <h2>Edit profile</h2>
+            <label>
+              Full name
+              <input
+                className="input"
+                value={profileDraft.name}
+                onChange={(event) => setProfileDraft((prev) => ({ ...prev, name: event.target.value }))}
+              />
+            </label>
+            <label>
+              Email
+              <input
+                className="input"
+                type="email"
+                value={profileDraft.email}
+                onChange={(event) => setProfileDraft((prev) => ({ ...prev, email: event.target.value }))}
+              />
+            </label>
+            <div className="modal-actions">
+              <button type="button" className="secondary-button" onClick={() => setEditOpen(false)}>
+                Cancel
+              </button>
+              <button type="submit" className="primary-button">
+                Save changes
+              </button>
+            </div>
+            {profileStatus === "saving" && <p className="status-text">Saving…</p>}
+          </form>
+        </div>
+      )}
     </div>
   )
 }
 
 SettingsScreen.propTypes = {
   user: PropTypes.shape({
+    id: PropTypes.string,
     email: PropTypes.string,
   }),
   categories: PropTypes.shape({
     income: PropTypes.array,
     expense: PropTypes.array,
   }),
+  budgets: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      name: PropTypes.string,
+      categoryBudgets: PropTypes.array,
+      transactions: PropTypes.array,
+    }),
+  ),
   onManageCategories: PropTypes.func,
 }
 
 SettingsScreen.defaultProps = {
   user: null,
   categories: { income: [], expense: [] },
+  budgets: [],
   onManageCategories: undefined,
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3543,3 +3543,705 @@ select.input {
     text-align: center;
   }
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Reports screen */
+.reports-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reports-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.reports-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.reports-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--gray-600);
+  font-size: 0.95rem;
+  max-width: 24rem;
+}
+
+.reports-period-select select {
+  appearance: none;
+  border: 1px solid var(--gray-300);
+  border-radius: var(--radius-lg);
+  padding: 0.5rem 1.5rem 0.5rem 0.75rem;
+  font-weight: 600;
+  background: white url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='%236b7280' d='M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z'/%3E%3C/svg%3E")
+    no-repeat right 0.5rem center/1rem;
+}
+
+.report-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.report-card {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.report-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.metric-tag {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--gray-600);
+  background: var(--gray-100);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.metric-tag.success {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--green-600);
+}
+
+.metric-tag.warning {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red-600);
+}
+
+.metric-tag.accent {
+  background: rgba(14, 165, 233, 0.18);
+  color: var(--primary-600);
+}
+
+.metric-value {
+  font-size: 2rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--gray-900);
+}
+
+.metric-value.expense {
+  color: var(--red-500);
+}
+
+.metric-value.income {
+  color: var(--green-500);
+}
+
+.metric-subtext {
+  color: var(--gray-500);
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.cash-burn-card {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.15), rgba(8, 145, 178, 0.05));
+  border: 1px solid rgba(14, 165, 233, 0.25);
+}
+
+.cash-burn-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.cash-burn-number {
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--primary-700);
+}
+
+.cash-burn-label {
+  color: var(--primary-700);
+  font-weight: 600;
+}
+
+.progress-bar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.progress-bar__track {
+  height: 0.75rem;
+  border-radius: var(--radius-full);
+  background: rgba(255, 255, 255, 0.6);
+  overflow: hidden;
+  border: 1px solid rgba(14, 165, 233, 0.25);
+}
+
+.progress-bar__fill {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--primary-500), var(--purple-500));
+}
+
+.progress-bar__legend {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--gray-600);
+}
+
+.category-card {
+  gap: 1.25rem;
+}
+
+.category-content {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.category-pie {
+  width: 140px;
+  height: 140px;
+  border-radius: 50%;
+  box-shadow: var(--shadow-md);
+}
+
+.category-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.category-list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.category-icon {
+  font-size: 1.5rem;
+}
+
+.category-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.category-name {
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.category-amount {
+  font-size: 0.85rem;
+  color: var(--gray-500);
+}
+
+.category-percent {
+  font-weight: 600;
+  color: var(--gray-700);
+}
+
+.category-color {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.category-empty {
+  color: var(--gray-500);
+}
+
+.chart-card {
+  gap: 1rem;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.chart-wrapper {
+  background: linear-gradient(180deg, rgba(14, 165, 233, 0.08), rgba(14, 165, 233, 0));
+  border-radius: var(--radius-lg);
+  padding: 0.5rem;
+  border: 1px solid rgba(14, 165, 233, 0.2);
+  height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.chart-wrapper svg {
+  width: 100%;
+  height: 100%;
+}
+
+.chart-empty {
+  color: var(--gray-500);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+.chart-toggle {
+  display: inline-flex;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+}
+
+.chart-toggle button {
+  border: none;
+  background: none;
+  padding: 0.4rem 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--gray-600);
+}
+
+.chart-toggle button.is-active {
+  background: var(--primary-500);
+  color: white;
+}
+
+.chart-legend {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.85rem;
+  color: var(--gray-600);
+}
+
+.legend-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  margin-right: 0.4rem;
+}
+
+.chart-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  color: var(--gray-500);
+}
+
+.trends-card .trends-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.trends-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.75rem;
+  border-radius: var(--radius-lg);
+  background: var(--gray-100);
+  color: var(--gray-700);
+}
+
+.trends-list li.highlight {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--green-600);
+  font-weight: 600;
+}
+
+.trend-icon {
+  font-size: 1.25rem;
+}
+
+.ai-card .ai-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ai-icon {
+  margin-right: 0.5rem;
+}
+
+.ai-status {
+  margin: 0;
+  color: var(--gray-600);
+  font-size: 0.9rem;
+}
+
+.ai-status.error {
+  color: var(--red-600);
+}
+
+.ai-summary {
+  margin: 0;
+  font-weight: 600;
+  color: var(--gray-800);
+}
+
+.ai-budget {
+  margin: 0;
+  color: var(--primary-700);
+  font-weight: 600;
+}
+
+.report-empty {
+  background: rgba(14, 165, 233, 0.08);
+  border: 1px dashed rgba(14, 165, 233, 0.4);
+  border-radius: var(--radius-xl);
+  padding: 1rem;
+  color: var(--primary-700);
+  font-weight: 500;
+}
+
+/* Settings screen */
+.settings-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.settings-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.settings-section h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--gray-800);
+}
+
+.settings-card {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.profile-card {
+  gap: 1.5rem;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: var(--radius-full);
+  background: linear-gradient(135deg, var(--primary-500), var(--purple-600));
+  color: white;
+  font-weight: 700;
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.profile-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  color: var(--primary-600);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+.link-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.subscription-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.subscription-tier {
+  margin: 0;
+  font-weight: 600;
+  color: var(--primary-700);
+}
+
+.settings-description {
+  color: var(--gray-600);
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+}
+
+.settings-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.settings-row h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.segmented-control {
+  display: inline-flex;
+  background: var(--gray-100);
+  border-radius: var(--radius-full);
+  padding: 0.25rem;
+  gap: 0.25rem;
+}
+
+.segmented-control button {
+  border: none;
+  background: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius-full);
+  font-weight: 600;
+  cursor: pointer;
+  color: var(--gray-600);
+}
+
+.segmented-control button.is-active {
+  background: white;
+  color: var(--primary-600);
+  box-shadow: var(--shadow-sm);
+}
+
+.toggle-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.toggle-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.theme-toggle button {
+  border: 1px solid var(--gray-300);
+  padding: 0.4rem 1rem;
+  border-radius: var(--radius-full);
+  background: white;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.theme-toggle button.is-active {
+  background: var(--primary-500);
+  border-color: transparent;
+  color: white;
+}
+
+.status-text {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--primary-600);
+}
+
+.status-text.error {
+  color: var(--red-600);
+}
+
+.about-card a {
+  color: var(--primary-600);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.about-card a:hover {
+  text-decoration: underline;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1100;
+}
+
+.modal {
+  background: white;
+  border-radius: var(--radius-xl);
+  padding: 1.5rem;
+  max-width: 22rem;
+  width: 100%;
+  box-shadow: var(--shadow-xl);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal h2 {
+  margin: 0;
+}
+
+.modal .input {
+  width: 100%;
+  margin-top: 0.35rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+/* Dark theme adjustments */
+[data-theme="dark"] body {
+  background: radial-gradient(circle at top, #1e293b, #0f172a);
+  color: var(--gray-100);
+}
+
+[data-theme="dark"] .container {
+  background-color: rgba(15, 23, 42, 0.92);
+  color: var(--gray-100);
+}
+
+[data-theme="dark"] .reports-header h1,
+[data-theme="dark"] .settings-section h2,
+[data-theme="dark"] .metric-value,
+[data-theme="dark"] .ai-summary,
+[data-theme="dark"] .settings-name {
+  color: white;
+}
+
+[data-theme="dark"] .reports-subtitle,
+[data-theme="dark"] .metric-subtext,
+[data-theme="dark"] .settings-description,
+[data-theme="dark"] .ai-status,
+[data-theme="dark"] .category-amount,
+[data-theme="dark"] .chart-legend,
+[data-theme="dark"] .chart-axis {
+  color: var(--gray-300);
+}
+
+[data-theme="dark"] .report-card,
+[data-theme="dark"] .settings-card,
+[data-theme="dark"] .modal {
+  background: rgba(30, 41, 59, 0.92);
+  border-color: rgba(148, 163, 184, 0.1);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .category-list li {
+  background: rgba(15, 23, 42, 0.35);
+  border-radius: var(--radius-lg);
+  padding: 0.25rem 0.5rem;
+}
+
+[data-theme="dark"] .trends-list li {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--gray-100);
+}
+
+[data-theme="dark"] .trends-list li.highlight {
+  background: rgba(16, 185, 129, 0.2);
+  color: var(--green-300);
+}
+
+[data-theme="dark"] .report-empty {
+  border-color: rgba(14, 165, 233, 0.5);
+  color: var(--primary-100);
+}
+
+[data-theme="dark"] .link-button,
+[data-theme="dark"] .about-card a {
+  color: var(--primary-200);
+}
+
+[data-theme="dark"] .chart-wrapper {
+  border-color: rgba(14, 165, 233, 0.35);
+}
+
+@media (max-width: 768px) {
+  .reports-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reports-period-select {
+    width: 100%;
+  }
+
+  .reports-period-select select {
+    width: 100%;
+  }
+
+  .category-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .subscription-card {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .settings-row {
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add reporting utilities to compute weekly and monthly spending analytics and cash burn metrics
- build a Reports screen with interactive charts, trend insights, and AI preview integrated into navigation
- expand the Settings hub with profile editing, preferences, theme controls, data export, cache tools, and refreshed styling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d73b93f1f0832e8833ef9eae967054