### PR TITLE
Refactor reports layout grid

### DIFF
--- a/src/screens/ReportsScreen.jsx
+++ b/src/screens/ReportsScreen.jsx
@@ -191,197 +191,207 @@ export default function ReportsScreen({ budgets, categories, onViewInsights }) {
         </div>
       )}
 
-      <section className="report-grid">
-        <article className="report-card">
-          <header>
-            <h2>Average Daily Spend</h2>
-            <span className="metric-tag">{report.range?.label}</span>
-          </header>
-          <p className="metric-value">{formatCurrency(report.avgDailySpend, currency)}</p>
-          <p className="metric-subtext">Across all logged expenses</p>
-        </article>
+      <div className="reports-layout">
+        <div className="reports-group reports-summary">
+          <section className="report-grid">
+            <article className="report-card">
+              <header>
+                <h2>Average Daily Spend</h2>
+                <span className="metric-tag">{report.range?.label}</span>
+              </header>
+              <p className="metric-value">{formatCurrency(report.avgDailySpend, currency)}</p>
+              <p className="metric-subtext">Across all logged expenses</p>
+            </article>
 
-        <article className="report-card">
-          <header>
-            <h2>Total Expenses</h2>
-            <span className="metric-tag">{report.range?.label}</span>
-          </header>
-          <p className="metric-value expense">{abbreviateCurrency(report.totalExpenses, currency)}</p>
-          <p className="metric-subtext">
-            Income: <strong>{abbreviateCurrency(report.totalIncome, currency)}</strong>
-          </p>
-        </article>
+            <article className="report-card">
+              <header>
+                <h2>Total Expenses</h2>
+                <span className="metric-tag">{report.range?.label}</span>
+              </header>
+              <p className="metric-value expense">{abbreviateCurrency(report.totalExpenses, currency)}</p>
+              <p className="metric-subtext">
+                Income: <strong>{abbreviateCurrency(report.totalIncome, currency)}</strong>
+              </p>
+            </article>
 
-        <article className="report-card">
-          <header>
-            <h2>Net Balance</h2>
-            <span className={`metric-tag ${report.balance >= 0 ? "success" : "warning"}`}>
-              {report.balance >= 0 ? "Surplus" : "Deficit"}
-            </span>
-          </header>
-          <p className={`metric-value ${report.balance >= 0 ? "income" : "expense"}`}>
-            {abbreviateCurrency(report.balance, currency)}
-          </p>
-          <p className="metric-subtext">
-            {report.balance >= 0 ? "Great job staying ahead" : "Review discretionary categories"}
-          </p>
-        </article>
-      </section>
+            <article className="report-card">
+              <header>
+                <h2>Net Balance</h2>
+                <span className={`metric-tag ${report.balance >= 0 ? "success" : "warning"}`}>
+                  {report.balance >= 0 ? "Surplus" : "Deficit"}
+                </span>
+              </header>
+              <p className={`metric-value ${report.balance >= 0 ? "income" : "expense"}`}>
+                {abbreviateCurrency(report.balance, currency)}
+              </p>
+              <p className="metric-subtext">
+                {report.balance >= 0 ? "Great job staying ahead" : "Review discretionary categories"}
+              </p>
+            </article>
+          </section>
 
-      <section className="report-card cash-burn-card">
-        <header>
-          <div>
-            <h2>Cash Burn</h2>
-            <p className="metric-subtext">Monitoring current month budgets</p>
-          </div>
-          <span className="metric-tag accent">{cashBurn.projectedDaysLeft ? `${Math.floor(cashBurn.projectedDaysLeft)} days left` : "Stable"}</span>
-        </header>
-        <div className="cash-burn-body">
-          <div className="cash-burn-number">{formatCurrency(cashBurn.avgDailySpend, currency)}</div>
-          <div className="cash-burn-label">Average daily spend</div>
-          <div className="progress-bar">
-            <div className="progress-bar__track" aria-hidden="true">
-              <div
-                className="progress-bar__fill"
-                style={{ width: `${Math.min(100, Math.round((cashBurn.progress || 0) * 100))}%` }}
-              />
-            </div>
-            <div className="progress-bar__legend">
-              <span>Spent {formatCurrency(cashBurn.spent, currency)}</span>
-              <span>Budgeted {formatCurrency(cashBurn.totalBudgeted, currency)}</span>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="report-card category-card">
-        <header>
-          <h2>Category Breakdown</h2>
-          <p className="metric-subtext">Expense mix for {report.range?.label}</p>
-        </header>
-        <div className="category-content">
-          <div className="category-pie" style={{ background: buildPieBackground(breakdown) }} aria-hidden="true" />
-          <ul className="category-list">
-            {breakdown.length ? (
-              breakdown.map((entry, index) => (
-                <li key={entry.key}>
-                  <span className="category-icon" aria-hidden="true">
-                    {getCategoryIcon(entry.label, categories)}
-                  </span>
-                  <div className="category-info">
-                    <span className="category-name">{entry.label}</span>
-                    <span className="category-amount">{formatCurrency(entry.amount, currency)}</span>
-                  </div>
-                  <span className="category-percent">{entry.percent.toFixed(1)}%</span>
-                  <span
-                    className="category-color"
-                    aria-hidden="true"
-                    style={{ backgroundColor: COLOR_PALETTE[index % COLOR_PALETTE.length] }}
+          <section className="report-card cash-burn-card">
+            <header>
+              <div>
+                <h2>Cash Burn</h2>
+                <p className="metric-subtext">Monitoring current month budgets</p>
+              </div>
+              <span className="metric-tag accent">
+                {cashBurn.projectedDaysLeft ? `${Math.floor(cashBurn.projectedDaysLeft)} days left` : "Stable"}
+              </span>
+            </header>
+            <div className="cash-burn-body">
+              <div className="cash-burn-number">{formatCurrency(cashBurn.avgDailySpend, currency)}</div>
+              <div className="cash-burn-label">Average daily spend</div>
+              <div className="progress-bar">
+                <div className="progress-bar__track" aria-hidden="true">
+                  <div
+                    className="progress-bar__fill"
+                    style={{ width: `${Math.min(100, Math.round((cashBurn.progress || 0) * 100))}%` }}
                   />
-                </li>
-              ))
-            ) : (
-              <li className="category-empty">Log expenses to populate category analytics.</li>
+                </div>
+                <div className="progress-bar__legend">
+                  <span>Spent {formatCurrency(cashBurn.spent, currency)}</span>
+                  <span>Budgeted {formatCurrency(cashBurn.totalBudgeted, currency)}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div className="reports-group reports-charts">
+          <section className="report-card category-card">
+            <header>
+              <h2>Category Breakdown</h2>
+              <p className="metric-subtext">Expense mix for {report.range?.label}</p>
+            </header>
+            <div className="category-content">
+              <div className="category-pie" style={{ background: buildPieBackground(breakdown) }} aria-hidden="true" />
+              <ul className="category-list">
+                {breakdown.length ? (
+                  breakdown.map((entry, index) => (
+                    <li key={entry.key}>
+                      <span className="category-icon" aria-hidden="true">
+                        {getCategoryIcon(entry.label, categories)}
+                      </span>
+                      <div className="category-info">
+                        <span className="category-name">{entry.label}</span>
+                        <span className="category-amount">{formatCurrency(entry.amount, currency)}</span>
+                      </div>
+                      <span className="category-percent">{entry.percent.toFixed(1)}%</span>
+                      <span
+                        className="category-color"
+                        aria-hidden="true"
+                        style={{ backgroundColor: COLOR_PALETTE[index % COLOR_PALETTE.length] }}
+                      />
+                    </li>
+                  ))
+                ) : (
+                  <li className="category-empty">Log expenses to populate category analytics.</li>
+                )}
+              </ul>
+            </div>
+          </section>
+
+          <section className="report-card chart-card">
+            <header className="chart-header">
+              <div>
+                <h2>Income vs Expenses</h2>
+                <p className="metric-subtext">Daily totals ({chartRange.label.toLowerCase()})</p>
+              </div>
+              <div className="chart-toggle" role="group" aria-label="Select chart period">
+                {PERIOD_OPTIONS.filter((option) => option.value !== "custom").map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={chartPeriod === option.value ? "is-active" : ""}
+                    onClick={() => setChartPeriod(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </header>
+            <div className="chart-wrapper" role="img" aria-label="Line chart comparing income and expenses">
+              {chartSeries.length ? (
+                <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} preserveAspectRatio="none">
+                  <polyline points={incomePath} fill="none" stroke="#3ED1B7" strokeWidth="3" />
+                  <polyline points={expensePath} fill="none" stroke="#FF6B6B" strokeWidth="3" />
+                </svg>
+              ) : (
+                <div className="chart-empty">Add income and expenses to unlock the comparison chart.</div>
+              )}
+            </div>
+            {chartSeries.length > 0 && (
+              <div className="chart-legend">
+                <span>
+                  <span className="legend-dot" style={{ backgroundColor: "#3ED1B7" }} /> Income
+                </span>
+                <span>
+                  <span className="legend-dot" style={{ backgroundColor: "#FF6B6B" }} /> Expenses
+                </span>
+              </div>
             )}
-          </ul>
+            {chartSeries.length > 0 && (
+              <div className="chart-axis">
+                {chartLabels.map((label) => (
+                  <span key={`${label.label}-${label.index}`}>{label.label}</span>
+                ))}
+              </div>
+            )}
+          </section>
         </div>
-      </section>
 
-      <section className="report-card chart-card">
-        <header className="chart-header">
-          <div>
-            <h2>Income vs Expenses</h2>
-            <p className="metric-subtext">Daily totals ({chartRange.label.toLowerCase()})</p>
-          </div>
-          <div className="chart-toggle" role="group" aria-label="Select chart period">
-            {PERIOD_OPTIONS.filter((option) => option.value !== "custom").map((option) => (
-              <button
-                key={option.value}
-                type="button"
-                className={chartPeriod === option.value ? "is-active" : ""}
-                onClick={() => setChartPeriod(option.value)}
-              >
-                {option.label}
+        <div className="reports-group reports-insights">
+          <section className="report-card trends-card">
+            <header>
+              <h2>Trends &amp; Insights</h2>
+              <p className="metric-subtext">Week-over-week category shifts</p>
+            </header>
+            <ul className="trends-list">
+              {trendStatements.map((statement, index) => (
+                <li key={statement} className={index === 0 ? "highlight" : ""}>
+                  <span className="trend-icon" aria-hidden="true">
+                    {index === 0 ? "📈" : "🧭"}
+                  </span>
+                  <span>{statement}</span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="report-card ai-card">
+            <header>
+              <div>
+                <h2>
+                  <span aria-hidden="true" className="ai-icon">
+                    ⚡
+                  </span>
+                  AI Insights Preview
+                </h2>
+                <p className="metric-subtext">Latest recommendations generated for your budgets</p>
+              </div>
+            </header>
+            <div className="ai-body">
+              {aiLoading ? (
+                <p className="ai-status">Gathering the latest insight...</p>
+              ) : aiError ? (
+                <p className="ai-status error">{aiError}</p>
+              ) : insightPreview ? (
+                <>
+                  {aiBudgetName && <p className="ai-budget">{aiBudgetName}</p>}
+                  <p className="ai-summary">{aiSummary || "Your AI co-pilot is ready with fresh guidance."}</p>
+                </>
+              ) : (
+                <p className="ai-status">Generate an AI report from any budget to see a personalized preview here.</p>
+              )}
+              <button type="button" className="primary-button" onClick={handleViewInsights} disabled={aiLoading}>
+                View Full AI Insights
               </button>
-            ))}
-          </div>
-        </header>
-        <div className="chart-wrapper" role="img" aria-label="Line chart comparing income and expenses">
-          {chartSeries.length ? (
-            <svg viewBox={`0 0 ${chartWidth} ${chartHeight}`} preserveAspectRatio="none">
-              <polyline points={incomePath} fill="none" stroke="#3ED1B7" strokeWidth="3" />
-              <polyline points={expensePath} fill="none" stroke="#FF6B6B" strokeWidth="3" />
-            </svg>
-          ) : (
-            <div className="chart-empty">Add income and expenses to unlock the comparison chart.</div>
-          )}
+            </div>
+          </section>
         </div>
-        {chartSeries.length > 0 && (
-          <div className="chart-legend">
-            <span>
-              <span className="legend-dot" style={{ backgroundColor: "#3ED1B7" }} /> Income
-            </span>
-            <span>
-              <span className="legend-dot" style={{ backgroundColor: "#FF6B6B" }} /> Expenses
-            </span>
-          </div>
-        )}
-        {chartSeries.length > 0 && (
-          <div className="chart-axis">
-            {chartLabels.map((label) => (
-              <span key={`${label.label}-${label.index}`}>{label.label}</span>
-            ))}
-          </div>
-        )}
-      </section>
-
-      <section className="report-card trends-card">
-        <header>
-          <h2>Trends &amp; Insights</h2>
-          <p className="metric-subtext">Week-over-week category shifts</p>
-        </header>
-        <ul className="trends-list">
-          {trendStatements.map((statement, index) => (
-            <li key={statement} className={index === 0 ? "highlight" : ""}>
-              <span className="trend-icon" aria-hidden="true">
-                {index === 0 ? "📈" : "🧭"}
-              </span>
-              <span>{statement}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section className="report-card ai-card">
-        <header>
-          <div>
-            <h2>
-              <span aria-hidden="true" className="ai-icon">
-                ⚡
-              </span>
-              AI Insights Preview
-            </h2>
-            <p className="metric-subtext">Latest recommendations generated for your budgets</p>
-          </div>
-        </header>
-        <div className="ai-body">
-          {aiLoading ? (
-            <p className="ai-status">Gathering the latest insight...</p>
-          ) : aiError ? (
-            <p className="ai-status error">{aiError}</p>
-          ) : insightPreview ? (
-            <>
-              {aiBudgetName && <p className="ai-budget">{aiBudgetName}</p>}
-              <p className="ai-summary">{aiSummary || "Your AI co-pilot is ready with fresh guidance."}</p>
-            </>
-          ) : (
-            <p className="ai-status">Generate an AI report from any budget to see a personalized preview here.</p>
-          )}
-          <button type="button" className="primary-button" onClick={handleViewInsights} disabled={aiLoading}>
-            View Full AI Insights
-          </button>
-        </div>
-      </section>
+      </div>
     </div>
   )
 }

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -3562,6 +3562,41 @@ select.input {
   gap: 1.5rem;
 }
 
+.reports-layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: 1fr;
+}
+
+.reports-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.reports-group .report-grid {
+  margin: 0;
+}
+
+.reports-group.reports-summary {
+  gap: 1.5rem;
+}
+
+.reports-group.reports-charts,
+.reports-group.reports-insights {
+  gap: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .reports-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reports-group.reports-summary {
+    grid-column: 1 / -1;
+  }
+}
+
 .reports-header {
   display: flex;
   align-items: flex-start;
@@ -3607,7 +3642,9 @@ select.input {
   border: 1px solid rgba(15, 23, 42, 0.05);
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+  margin: 0;
+  width: 100%;
 }
 
 .report-card header {


### PR DESCRIPTION
## Summary
- group report summary, charts, and insights content into a new `.reports-layout` container
- apply responsive grid styling for the new layout and tune `.report-card` spacing for consistent alignment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7427654c0832e9c83c29331af8daf