### PR TITLE
Make budget cards navigable

### DIFF
--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -88,6 +88,7 @@ export default function BudgetsScreen({
   )
 
   const openBudget = (budget) => {
+    setOpenMenuId(null)
     setSelectedBudget(budget)
     setViewMode("details")
   }
@@ -355,10 +356,26 @@ export default function BudgetsScreen({
           const cycleType = budget.cycleMetadata?.type || "monthly"
           const cycleLabel = getCycleLabel(cycleType)
 
+          const handleCardKeyDown = (event) => {
+            if (event.currentTarget !== event.target) return
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault()
+              openBudget(budget)
+            }
+          }
+
           return (
-            <div key={budget.id} className="budgetCard">
+            <div
+              key={budget.id}
+              className="budgetCard"
+              role="button"
+              tabIndex={0}
+              aria-label={`View details for ${budget.name}`}
+              onClick={() => openBudget(budget)}
+              onKeyDown={handleCardKeyDown}
+            >
               <div className="budgetCard-content">
-                <div className="budgetCard-info" onClick={() => openBudget(budget)}>
+                <div className="budgetCard-info">
                   <div className="budgetCycleRow">
                     <span className={`cycle-pill cycle-${cycleType}`}>{cycleLabel}</span>
                     <div className={`pacing-indicator pacing-${overallPacing.status}`} title={overallPacing.tooltip} role="status">

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1309,6 +1309,11 @@ body {
   z-index: 1;
 }
 
+.budgetCard:focus-visible {
+  outline: 3px solid var(--primary-500);
+  outline-offset: 4px;
+}
+
 .budgetCard-content {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- make budget cards behave like interactive buttons so users can always open budget details
- reset any open budget menus when a card is activated and add keyboard handling for Enter/Space
- add a visible focus ring for keyboard navigation on budget cards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81ae88454832ea0e3f6b412d3301a