### PR TITLE
Add ad slot guardrails and latency instrumentation

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,23 @@
+# Performance Validation
+
+Pocket Budget instruments render performance for the budget overview and AI insights experiences so we can spot latency regressions early.
+
+## Instrumentation
+- `useRenderTimer` wraps key surfaces (`BudgetsScreen` and `AIInsightsScreen`) and records render duration using `performance.now()`.
+- Each render logs a debug message (prefixed with `[perf]`) and surfaces `data-perf-*` attributes for automated capture.
+- Thresholds guard against regressions:
+  - Budget overview summary: 500 ms target (4G).
+  - AI insights: 700 ms cached, 1500 ms when regenerating.
+- When a threshold is exceeded a console warning is emitted so the regression is visible even without tooling.
+
+## Manual Verification
+1. Start the app (`npm run dev`).
+2. Open Chrome DevTools → Performance → **Capture Settings** and throttle to “Fast 4G / 4x CPU slowdown”.
+3. Load the Budgets screen and note the `[perf] budgets-overview` log; ensure it stays ≤500 ms.
+4. Navigate to AI Insights, trigger a refresh, and review the `[perf] ai-insights-cards` log for both cached (~700 ms) and regenerated (~1.5 s) paths.
+5. Watch for automatic warnings in the console. These are emitted if thresholds are breached.
+
+## Regression Safeguards
+- The ad slot reserves layout space with `min-height` so lazy ad loads do not shift content.
+- The performance attributes can be asserted in automated end-to-end tests (e.g., Playwright) by reading `data-perf-duration`.
+- When optimizing, prefer memoised selectors and batched Supabase requests to keep render durations inside the thresholds.

--- a/src/components/AdSlot.jsx
+++ b/src/components/AdSlot.jsx
@@ -5,6 +5,7 @@ const DEFAULT_HEIGHT = 140
 
 export default function AdSlot({ placement, minHeight = DEFAULT_HEIGHT, headline, body }) {
   const [isLoaded, setIsLoaded] = useState(false)
+  const resolvedMinHeight = typeof minHeight === "number" ? `${minHeight}px` : minHeight
 
   useEffect(() => {
     const timer = setTimeout(() => setIsLoaded(true), 160)
@@ -14,7 +15,7 @@ export default function AdSlot({ placement, minHeight = DEFAULT_HEIGHT, headline
   return (
     <div
       className="ad-slot"
-      style={{ minHeight }}
+      style={{ minHeight: resolvedMinHeight, "--ad-slot-min-height": resolvedMinHeight }}
       data-ad-placement={placement}
       data-ad-loaded={isLoaded}
       role="complementary"

--- a/src/hooks/useRenderTimer.js
+++ b/src/hooks/useRenderTimer.js
@@ -20,17 +20,26 @@ export function useRenderTimer({
   enabled = true,
 } = {}) {
   const startRef = useRef(enabled ? performance.now() : 0)
+  const lastLoggedRef = useRef(null)
   const [duration, setDuration] = useState(null)
 
   useEffect(() => {
     if (!enabled) return undefined
     startRef.current = performance.now()
+    lastLoggedRef.current = null
     if (name) {
       performance.mark?.(`${name}:start`)
     }
     let frame = requestAnimationFrame(() => {
       const elapsed = performance.now() - startRef.current
       setDuration(elapsed)
+      const rounded = Number.isFinite(elapsed) ? Number(elapsed.toFixed(1)) : null
+      if (rounded !== null && lastLoggedRef.current !== rounded) {
+        console.debug?.(
+          `[perf] ${name || "render"} completed in ${rounded.toFixed(1)}ms`,
+        )
+        lastLoggedRef.current = rounded
+      }
       if (name) {
         performance.mark?.(`${name}:end`)
         performance.measure?.(name, `${name}:start`, `${name}:end`)

--- a/src/screens/BudgetDetailsScreen.jsx
+++ b/src/screens/BudgetDetailsScreen.jsx
@@ -13,6 +13,8 @@ const CYCLE_OPTIONS = [
   { type: "custom", label: "Custom" },
 ]
 
+const PAYWALLED_CYCLE_TYPES = new Set(["per-paycheck", "custom"])
+
 const getCycleLabel = (type) => {
   const option = CYCLE_OPTIONS.find((candidate) => candidate.type === type)
   if (option) return option.label
@@ -971,6 +973,10 @@ function BudgetDetailsScreen({
 
   const cycleType = budget.cycleMetadata?.type || "monthly"
   const cycleLabel = getCycleLabel(cycleType)
+  const isPaywalledCycle = PAYWALLED_CYCLE_TYPES.has(cycleType)
+  const cyclePillLabel = `${cycleLabel}${
+    isPaywalledCycle ? " (Pocket Budget Plus feature)" : ""
+  }`
   const cycleStartDate = budget.cycleMetadata?.currentStart
     ? new Date(budget.cycleMetadata.currentStart)
     : null
@@ -1153,8 +1159,16 @@ function BudgetDetailsScreen({
       />
 
       <div className="budget-cycle-banner">
-        <div className={`cycle-pill cycle-${cycleType}`}>
-          {cycleLabel}
+        <div
+          className={`cycle-pill cycle-${cycleType}${isPaywalledCycle ? " is-locked" : ""}`}
+          aria-label={cyclePillLabel}
+        >
+          {isPaywalledCycle && (
+            <span className="cycle-pill-lock" aria-hidden="true">
+              🔒
+            </span>
+          )}
+          <span className="cycle-pill-text">{cycleLabel}</span>
         </div>
         <div className="cycle-meta">
           <span>Started {cycleStartDisplay}</span>

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -36,6 +36,8 @@ const CYCLE_OPTIONS = [
   },
 ]
 
+const PAYWALLED_CYCLE_TYPES = new Set(["per-paycheck", "custom"])
+
 const getCycleLabel = (type) => {
   const option = CYCLE_OPTIONS.find((candidate) => candidate.type === type)
   if (option) {
@@ -303,8 +305,8 @@ export default function BudgetsScreen({
         </div>
       </div>
 
-      {budgets.length > 0 && (
-        <>
+      <div className="overview-summary-stack">
+        {budgets.length > 0 && (
           <div className="cycle-summary-card" {...summaryPerf.dataAttributes}>
             <div className="cycle-summary-title">Budget cycles</div>
             <div className="cycle-summary-stats">
@@ -316,13 +318,13 @@ export default function BudgetsScreen({
               ))}
             </div>
           </div>
-          <AdSlot
-            placement="overview-summary"
-            headline="Earn cash back on planned spend"
-            body="Use the Pocket Budget partner card and turn category budgets into weekly rewards."
-          />
-        </>
-      )}
+        )}
+        <AdSlot
+          placement="overview-summary"
+          headline="Earn cash back on planned spend"
+          body="Use the Pocket Budget partner card and turn category budgets into weekly rewards."
+        />
+      </div>
 
       {budgets.length === 0 ? (
         <div className="empty-state">
@@ -380,6 +382,11 @@ export default function BudgetsScreen({
             }
           }
 
+          const isPaywalledCycle = PAYWALLED_CYCLE_TYPES.has(cycleType)
+          const cyclePillLabel = `${cycleLabel}${
+            isPaywalledCycle ? " (Pocket Budget Plus feature)" : ""
+          }`
+
           return (
             <div
               key={budget.id}
@@ -393,7 +400,17 @@ export default function BudgetsScreen({
               <div className="budgetCard-content">
                 <div className="budgetCard-info">
                   <div className="budgetCycleRow">
-                    <span className={`cycle-pill cycle-${cycleType}`}>{cycleLabel}</span>
+                    <span
+                      className={`cycle-pill cycle-${cycleType}${isPaywalledCycle ? " is-locked" : ""}`}
+                      aria-label={cyclePillLabel}
+                    >
+                      {isPaywalledCycle && (
+                        <span className="cycle-pill-lock" aria-hidden="true">
+                          🔒
+                        </span>
+                      )}
+                      <span className="cycle-pill-text">{cycleLabel}</span>
+                    </span>
                     <div className={`pacing-indicator pacing-${overallPacing.status}`} title={overallPacing.tooltip} role="status">
                       <span className="pacing-dot" aria-hidden="true" />
                       <span className="pacing-label">{overallPacing.label}</span>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1326,6 +1326,128 @@ body {
   cursor: pointer;
 }
 
+.overview-summary-stack {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cycle-summary-card {
+  background: white;
+  border: 1px solid var(--gray-200);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-sm);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cycle-summary-title {
+  font-weight: 700;
+  color: var(--gray-900);
+  font-size: 1.05rem;
+}
+
+.cycle-summary-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  color: var(--gray-600);
+}
+
+.cycle-chip,
+.cycle-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.8rem;
+  border-radius: var(--radius-full);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: var(--gray-100);
+  color: var(--gray-700);
+  line-height: 1;
+}
+
+.cycle-pill-lock {
+  font-size: 0.85em;
+  display: inline-flex;
+  align-items: center;
+}
+
+.cycle-pill-text {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1;
+}
+
+.cycle-pill.is-locked,
+.cycle-chip.cycle-per-paycheck {
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--primary-700);
+}
+
+.cycle-pill.cycle-per-paycheck {
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--primary-700);
+}
+
+.cycle-pill.cycle-custom,
+.cycle-chip.cycle-custom {
+  background: rgba(168, 85, 247, 0.12);
+  color: var(--purple-600);
+}
+
+.cycle-pill.cycle-monthly,
+.cycle-chip.cycle-monthly {
+  background: rgba(16, 185, 129, 0.12);
+  color: var(--green-600);
+}
+
+.budgetSummaryRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 0.75rem 0 1rem;
+}
+
+.budgetSummaryItem {
+  background: var(--gray-100);
+  border-radius: var(--radius-lg);
+  padding: 0.6rem 0.9rem;
+  font-size: 0.9rem;
+  color: var(--gray-600);
+}
+
+.budgetSummaryItem strong {
+  display: block;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--gray-900);
+}
+
+.budgetSummaryItem.guardrail-green,
+.guardrail-green,
+.guardrail-green strong {
+  color: var(--green-600);
+}
+
+.budgetSummaryItem.guardrail-yellow,
+.guardrail-yellow,
+.guardrail-yellow strong {
+  color: #d97706;
+}
+
+.budgetSummaryItem.guardrail-red,
+.guardrail-red,
+.guardrail-red strong {
+  color: var(--red-600);
+}
+
 .budgetNameRow {
   display: flex;
   align-items: center;
@@ -1358,6 +1480,11 @@ body {
   font-size: 1.125rem;
   font-weight: 600;
   color: var(--gray-900);
+}
+
+.budgetBalance span {
+  font-size: 1.35rem;
+  font-weight: 700;
 }
 
 .budgetItemContainer {
@@ -2652,6 +2779,7 @@ body {
   align-items: center;
   justify-content: space-between;
   width: 100%;
+  min-height: var(--ad-slot-min-height, 140px);
 }
 
 .ad-slot[data-ad-loaded="true"] {
@@ -2819,6 +2947,25 @@ body {
   height: 100%;
   background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
   animation: shimmer 0.6s;
+}
+
+@media (max-width: 640px) {
+  .cycle-summary-card {
+    padding: 1rem 1.25rem;
+  }
+
+  .cycle-summary-stats {
+    gap: 0.4rem;
+  }
+
+  .budgetCard-content {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .budgetSummaryItem {
+    flex: 1 1 100%;
+  }
 }
 
 /* Responsive improvements */


### PR DESCRIPTION
## Summary
- ensure the budgets overview always renders a sponsored ad slot with reserved space and styling updates
- add lock-aware cycle pills and guardrail color tokens so pacing states remain consistent across budgets
- log render latency via useRenderTimer and document the performance validation workflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8240626d8832eaed269ecef9be692