### PR TITLE
Add cached data hydration and skeleton UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -72,6 +72,73 @@ const sanitizeCategories = (value) => {
   })
 }
 
+const BUDGET_CACHE_VERSION = 1
+const CATEGORY_CACHE_VERSION = 1
+
+const getBudgetCacheKey = (userId) => `pb:cache:budgets:${userId}`
+const getCategoryCacheKey = (userId) => `pb:cache:categories:${userId}`
+
+const safeJsonParse = (value) => {
+  if (!value) return null
+  try {
+    return JSON.parse(value)
+  } catch (error) {
+    console.warn("Failed to parse cached payload", error)
+    return null
+  }
+}
+
+const normalizeCachedTransaction = (transaction) => ({
+  id: transaction.id,
+  name: transaction.name || "",
+  amount: Number(transaction.amount || 0),
+  budgetedAmount: transaction.budgetedAmount ?? transaction.budgeted_amount ?? null,
+  category: transaction.category || "",
+  type: transaction.type === "income" ? "income" : "expense",
+  date: transaction.date || null,
+  receipt: transaction.receipt ?? transaction.receipt_url ?? null,
+})
+
+const normalizeCachedBudget = (budget) => ({
+  id: budget.id,
+  name: budget.name || "Untitled Budget",
+  createdAt: budget.createdAt || budget.created_at || new Date().toLocaleDateString(),
+  categoryBudgets: Array.isArray(budget.categoryBudgets || budget.category_budgets)
+    ? (budget.categoryBudgets || budget.category_budgets).map((category) => ({
+        category: category.category || "",
+        budgetedAmount: Number(category.budgetedAmount ?? category.budgeted_amount ?? 0),
+      }))
+    : [],
+  transactions: Array.isArray(budget.transactions)
+    ? budget.transactions.map((transaction) => normalizeCachedTransaction(transaction))
+    : [],
+  metadata: budget.metadata || null,
+})
+
+const extractCachedBudgets = (value) => {
+  if (!value) return []
+  const budgetsArray = Array.isArray(value?.budgets) ? value.budgets : Array.isArray(value) ? value : []
+  return budgetsArray
+    .filter((budget) => budget && typeof budget === "object" && budget.id)
+    .map((budget) => normalizeCachedBudget(budget))
+}
+
+const prepareBudgetsForCache = (budgets) =>
+  (budgets || [])
+    .filter((budget) => budget && typeof budget === "object" && budget.id)
+    .map((budget) => normalizeCachedBudget(budget))
+
+const extractCachedCategories = (value) => {
+  if (!value) return null
+  const payload = value.categories ?? value
+  return sanitizeCategories(payload)
+}
+
+const prepareCategoriesForCache = (categories) => {
+  const sanitized = sanitizeCategories(categories)
+  return sanitized ? cloneCategories(sanitized) : null
+}
+
 function AppContent() {
   const { user, loading: authLoading, initializing, status: authStatus } = useAuth()
   const [budgets, setBudgetsState] = useState([])
@@ -79,12 +146,37 @@ function AppContent() {
   const [selectedBudget, setSelectedBudget] = useState(null)
   const [viewMode, setViewMode] = useState("budgets")
   const [dataPhase, setDataPhase] = useState("idle")
+  const [cacheStatus, setCacheStatus] = useState({ budgets: false, categories: false })
   const lastFetchedUserIdRef = useRef(null)
+  const cacheStatusRef = useRef(cacheStatus)
+  const refreshTimerRef = useRef(null)
+  const budgetsCacheSnapshotRef = useRef("")
+  const categoriesCacheSnapshotRef = useRef("")
+  const hasCachedData = cacheStatus.budgets || cacheStatus.categories
+
+  useEffect(() => {
+    cacheStatusRef.current = cacheStatus
+  }, [cacheStatus])
 
   const shouldShowAuthLoading = initializing || authLoading || authStatus === "auth-transition"
   const markDataAsStale = useCallback(() => {
     if (!user?.id) return
-    lastFetchedUserIdRef.current = null
+    if (refreshTimerRef.current) return
+
+    const hasCache = cacheStatusRef.current.budgets || cacheStatusRef.current.categories
+    const delay = hasCache ? 200 : 0
+
+    refreshTimerRef.current = setTimeout(() => {
+      refreshTimerRef.current = null
+      lastFetchedUserIdRef.current = null
+      const latestHasCache = cacheStatusRef.current.budgets || cacheStatusRef.current.categories
+      setDataPhase((previous) => {
+        if (!latestHasCache && previous === "loading") {
+          return previous
+        }
+        return latestHasCache ? "refreshing" : "loading"
+      })
+    }, delay)
   }, [user?.id])
 
   const applyMetadata = useCallback((budget, metadataOverride) => {
@@ -135,8 +227,146 @@ function AppContent() {
       setViewMode("budgets")
       setDataPhase("idle")
       lastFetchedUserIdRef.current = null
+      budgetsCacheSnapshotRef.current = ""
+      categoriesCacheSnapshotRef.current = ""
+      cacheStatusRef.current = { budgets: false, categories: false }
+      setCacheStatus({ budgets: false, categories: false })
     }
   }, [user, setBudgets])
+
+  useEffect(() => {
+    if (!user?.id) return
+    if (typeof window === "undefined") return
+
+    let budgetsFound = false
+    let categoriesFound = false
+
+    try {
+      const rawBudgets = window.localStorage.getItem(getBudgetCacheKey(user.id))
+      const parsedBudgets = safeJsonParse(rawBudgets)
+      const cachedBudgets = extractCachedBudgets(parsedBudgets)
+      if (cachedBudgets.length > 0) {
+        budgetsFound = true
+        budgetsCacheSnapshotRef.current = JSON.stringify(cachedBudgets)
+        setBudgets(cachedBudgets)
+        setSelectedBudget((current) => {
+          if (current && cachedBudgets.some((budget) => budget.id === current.id)) {
+            return current
+          }
+          return cachedBudgets[0] || current
+        })
+      } else {
+        budgetsCacheSnapshotRef.current = ""
+      }
+    } catch (error) {
+      console.warn("Failed to restore cached budgets", error)
+      budgetsCacheSnapshotRef.current = ""
+    }
+
+    try {
+      const rawCategories = window.localStorage.getItem(getCategoryCacheKey(user.id))
+      const parsedCategories = safeJsonParse(rawCategories)
+      const cachedCategories = extractCachedCategories(parsedCategories)
+      if (cachedCategories) {
+        categoriesFound = true
+        categoriesCacheSnapshotRef.current = JSON.stringify(cachedCategories)
+        setCategories(cachedCategories)
+      } else {
+        categoriesCacheSnapshotRef.current = ""
+      }
+    } catch (error) {
+      console.warn("Failed to restore cached categories", error)
+      categoriesCacheSnapshotRef.current = ""
+    }
+
+    if (budgetsFound || categoriesFound) {
+      setDataPhase((prev) => (prev === "idle" ? "hydrated" : prev))
+    }
+
+    setCacheStatus((prev) => {
+      const next = { budgets: budgetsFound, categories: categoriesFound }
+      if (prev.budgets === next.budgets && prev.categories === next.categories) {
+        return prev
+      }
+      return next
+    })
+  }, [user?.id, setBudgets, setSelectedBudget])
+
+  useEffect(
+    () => () => {
+      if (refreshTimerRef.current) {
+        clearTimeout(refreshTimerRef.current)
+      }
+    },
+    [],
+  )
+
+  useEffect(() => {
+    if (!user?.id) return
+    if (typeof window === "undefined") return
+    if (dataPhase === "idle") return
+
+    const payload = prepareBudgetsForCache(budgets)
+    const serialized = JSON.stringify(payload)
+
+    if (serialized !== budgetsCacheSnapshotRef.current) {
+      budgetsCacheSnapshotRef.current = serialized
+      try {
+        window.localStorage.setItem(
+          getBudgetCacheKey(user.id),
+          JSON.stringify({
+            version: BUDGET_CACHE_VERSION,
+            savedAt: Date.now(),
+            budgets: payload,
+          }),
+        )
+      } catch (error) {
+        console.warn("Failed to persist budgets cache", error)
+      }
+    }
+
+    setCacheStatus((prev) => {
+      const hasBudgets = payload.length > 0
+      if (prev.budgets === hasBudgets) {
+        return prev
+      }
+      return { ...prev, budgets: hasBudgets }
+    })
+  }, [budgets, user?.id, dataPhase])
+
+  useEffect(() => {
+    if (!user?.id) return
+    if (typeof window === "undefined") return
+    if (dataPhase === "idle") return
+
+    const payload = prepareCategoriesForCache(categories)
+    if (!payload) return
+
+    const serialized = JSON.stringify(payload)
+
+    if (serialized !== categoriesCacheSnapshotRef.current) {
+      categoriesCacheSnapshotRef.current = serialized
+      try {
+        window.localStorage.setItem(
+          getCategoryCacheKey(user.id),
+          JSON.stringify({
+            version: CATEGORY_CACHE_VERSION,
+            savedAt: Date.now(),
+            categories: payload,
+          }),
+        )
+      } catch (error) {
+        console.warn("Failed to persist categories cache", error)
+      }
+    }
+
+    setCacheStatus((prev) => {
+      if (prev.categories) {
+        return prev
+      }
+      return { ...prev, categories: true }
+    })
+  }, [categories, user?.id, dataPhase])
 
   useEffect(() => {
     if (!user || authLoading || initializing) {
@@ -150,7 +380,7 @@ function AppContent() {
     const currentUserId = user.id
     lastFetchedUserIdRef.current = currentUserId
     let isCurrent = true
-    setDataPhase("loading")
+    setDataPhase(hasCachedData ? "refreshing" : "loading")
 
     const fetchBudgets = getBudgets(currentUserId)
     const fetchCategories = getUserCategories(currentUserId)
@@ -183,7 +413,7 @@ function AppContent() {
             receipt: tx.receipt_url ?? null,
           })),
         }))
-        setBudgets(normalizedBudgets.map((budget) => applyMetadata(budget)))
+        setBudgets(normalizedBudgets)
       } else {
         console.error("Unexpected error resolving budgets:", budgetResult.reason)
         encounteredError = true
@@ -221,7 +451,7 @@ function AppContent() {
     return () => {
       isCurrent = false
     }
-  }, [user, authLoading, initializing, setBudgets, applyMetadata])
+  }, [user, authLoading, initializing, setBudgets, hasCachedData])
 
   const updateCategories = async (nextCategories) => {
     const validatedCategories = sanitizeCategories(nextCategories)
@@ -332,7 +562,11 @@ function AppContent() {
     return <LoadingScreen message="Preparing your experience" />
   }
 
-  if (user && dataPhase !== "ready") {
+  const isBudgetDataPending = user && dataPhase !== "ready" && budgets.length === 0
+  const shouldBlockForData =
+    user && !hasCachedData && (dataPhase === "idle" || dataPhase === "loading")
+
+  if (shouldBlockForData) {
     return <LoadingScreen message={dataPhase === "loading" ? "Loading your budgets" : "Setting things up"} />
   }
 
@@ -351,6 +585,7 @@ function AppContent() {
           onMetadataChange={handleBudgetMetadataUpdate}
           onMetadataRemove={handleBudgetMetadataRemoval}
           onDataMutated={markDataAsStale}
+          isLoadingBudgets={isBudgetDataPending}
         />
       )}
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -173,6 +173,16 @@ export function AuthProvider({ children }) {
           setStatus("signed-out")
           return
         }
+        const { data: localSessionData } = await supabase.auth.getSession()
+        const localUser = localSessionData?.session?.user
+
+        if (localUser) {
+          setStatus("restoring-session")
+          persistLoginTimestamp()
+          await handleSession(localUser)
+          return
+        }
+
         const timeout = new Promise((_, reject) =>
           setTimeout(() => reject(new Error("Session lookup timed out")), SESSION_TIMEOUT_MS),
         )

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -127,12 +127,25 @@ const normalizeBudgetRecord = (budget) => ({
   transactions: (budget.transactions || []).map(normalizeTransactionRecord),
 })
 
-export const getBudgets = async (userId) => {
-  const { data, error } = await supabase
+export const getBudgets = async (userId, options = {}) => {
+  const { range, limit } = options
+
+  let query = supabase
     .from("budgets")
-    .select(`*, transactions (*)`)
+    .select(
+      `id, name, created_at, category_budgets, ` +
+        `transactions (id, name, amount, budgeted_amount, category, type, date, receipt_url)`,
+    )
     .eq("user_id", userId)
     .order("created_at", { ascending: false })
+
+  if (range && typeof range.from === "number" && typeof range.to === "number") {
+    query = query.range(range.from, range.to)
+  } else if (typeof limit === "number") {
+    query = query.limit(limit)
+  }
+
+  const { data, error } = await query
 
   return {
     data: (data || []).map(normalizeBudgetRecord),
@@ -150,7 +163,10 @@ export const createBudget = async (userId, budgetData) => {
   const result = await supabase
     .from("budgets")
     .insert([payload])
-    .select(`*, transactions (*)`)
+    .select(
+      `id, name, created_at, category_budgets, ` +
+        `transactions (id, name, amount, budgeted_amount, category, type, date, receipt_url)`,
+    )
 
   if (result.error) {
     return { data: null, error: result.error }
@@ -161,7 +177,10 @@ export const createBudget = async (userId, budgetData) => {
   if (!rows.length) {
     const { data: latest, error: fetchError } = await supabase
       .from("budgets")
-      .select(`*, transactions (*)`)
+      .select(
+        `id, name, created_at, category_budgets, ` +
+          `transactions (id, name, amount, budgeted_amount, category, type, date, receipt_url)`,
+      )
       .eq("user_id", userId)
       .order("created_at", { ascending: false })
       .limit(1)
@@ -283,7 +302,7 @@ export const getCashBurn = async (userId) => {
 }
 
 export const getUserCategories = async (userId) => {
-  return supabase.from("user_categories").select("*").eq("user_id", userId).single()
+  return supabase.from("user_categories").select("categories").eq("user_id", userId).single()
 }
 
 export const updateUserCategories = async (userId, categories) => {
@@ -295,7 +314,7 @@ export const updateUserCategories = async (userId, categories) => {
         categories,
       },
     ])
-    .select()
+    .select("categories")
 }
 
 const DEFAULT_MILESTONES = [25, 50, 75, 100]

--- a/src/screens/BudgetsScreen.jsx
+++ b/src/screens/BudgetsScreen.jsx
@@ -61,6 +61,23 @@ const buildInitialConfig = (existingBudgetsLength) => ({
 
 const formatCurrency = (value) => `$${Number.parseFloat(value || 0).toFixed(2)}`
 
+function BudgetSkeletonList() {
+  return (
+    <div className="skeleton-stack" role="status" aria-live="polite" aria-busy="true">
+      {[0, 1, 2].map((index) => (
+        <div key={index} className="skeleton-card">
+          <div className="skeleton-line skeleton-line-lg" />
+          <div className="skeleton-line skeleton-line-md" />
+          <div className="skeleton-line skeleton-line-sm" />
+          <div className="skeleton-line skeleton-line-lg skeleton-line-offset" />
+          <div className="skeleton-line skeleton-line-md" />
+        </div>
+      ))}
+      <span className="sr-only">Loading budgets…</span>
+    </div>
+  )
+}
+
 export default function BudgetsScreen({
   budgets,
   setSelectedBudget,
@@ -70,6 +87,7 @@ export default function BudgetsScreen({
   onMetadataChange,
   onMetadataRemove,
   onDataMutated,
+  isLoadingBudgets,
 }) {
   const [editingBudgetId, setEditingBudgetId] = useState(null)
   const [budgetNameInput, setBudgetNameInput] = useState("")
@@ -327,19 +345,23 @@ export default function BudgetsScreen({
       </div>
 
       {budgets.length === 0 ? (
-        <div className="empty-state">
-          <p>Welcome to Pocket Budget! Create your first budget to get started.</p>
-          <button
-            className="primary-button"
-            onClick={() => {
-              setCreateConfig(buildInitialConfig(budgets.length))
-              setShowCreateModal(true)
-            }}
-            disabled={loading}
-          >
-            Start a Monthly Budget
-          </button>
-        </div>
+        isLoadingBudgets ? (
+          <BudgetSkeletonList />
+        ) : (
+          <div className="empty-state">
+            <p>Welcome to Pocket Budget! Create your first budget to get started.</p>
+            <button
+              className="primary-button"
+              onClick={() => {
+                setCreateConfig(buildInitialConfig(budgets.length))
+                setShowCreateModal(true)
+              }}
+              disabled={loading}
+            >
+              Start a Monthly Budget
+            </button>
+          </div>
+        )
       ) : (
         budgets.map((budget) => {
           const pacing = calculateBudgetPacing(budget)
@@ -743,10 +765,12 @@ BudgetsScreen.propTypes = {
   onMetadataChange: PropTypes.func,
   onMetadataRemove: PropTypes.func,
   onDataMutated: PropTypes.func,
+  isLoadingBudgets: PropTypes.bool,
 }
 
 BudgetsScreen.defaultProps = {
   onMetadataChange: undefined,
   onMetadataRemove: undefined,
   onDataMutated: undefined,
+  isLoadingBudgets: false,
 }

--- a/src/screens/SettingsScreen.jsx
+++ b/src/screens/SettingsScreen.jsx
@@ -105,7 +105,6 @@ export default function SettingsScreen({ user, categories, budgets, onManageCate
   const [preferencesStatus, setPreferencesStatus] = useState(null)
   const [preferencesError, setPreferencesError] = useState(null)
   const [utilityStatus, setUtilityStatus] = useState(null)
-  const [utilityLoading, setUtilityLoading] = useState(false)
   const { preference, effectiveTheme, setThemePreference, resetToSystem } = useThemePreference()
 
   useEffect(() => {
@@ -219,33 +218,6 @@ export default function SettingsScreen({ user, categories, budgets, onManageCate
     anchor.click()
     URL.revokeObjectURL(url)
     setUtilityStatus("Data exported successfully")
-  }
-
-  const handleClearCache = async () => {
-    if (typeof window === "undefined") return
-    setUtilityLoading(true)
-    setUtilityStatus(null)
-    try {
-      const keysToRemove = []
-      for (let i = 0; i < localStorage.length; i += 1) {
-        const key = localStorage.key(i)
-        if (!key) continue
-        if (key.startsWith("pb:") || key.includes("budgets_") || key.includes("transactions_") || key.includes("mock")) {
-          keysToRemove.push(key)
-        }
-      }
-      keysToRemove.forEach((key) => localStorage.removeItem(key))
-      if (window.caches) {
-        const cacheKeys = await window.caches.keys()
-        await Promise.all(cacheKeys.map((cacheKey) => window.caches.delete(cacheKey)))
-      }
-      setUtilityStatus("Local cache cleared")
-    } catch (error) {
-      console.error("Failed to clear cache", error)
-      setUtilityStatus(error.message || "Unable to clear cache")
-    } finally {
-      setUtilityLoading(false)
-    }
   }
 
   const incomeCount = categories?.income?.length || 0
@@ -411,15 +383,6 @@ export default function SettingsScreen({ user, categories, budgets, onManageCate
             </button>
           </div>
 
-          <div className="settings-row">
-            <div>
-              <h3>Clear cache</h3>
-              <p className="settings-description">Remove stored sessions and offline data.</p>
-            </div>
-            <button type="button" className="link-button" onClick={handleClearCache} disabled={utilityLoading}>
-              {utilityLoading ? "Clearing…" : "Clear cache"}
-            </button>
-          </div>
           {utilityStatus && <p className="status-text">{utilityStatus}</p>}
         </div>
       </section>

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -1333,6 +1333,68 @@ body {
   gap: 1rem;
 }
 
+.skeleton-stack {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.skeleton-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--gray-200);
+  background: var(--gray-100);
+  padding: 1.5rem;
+  min-height: 140px;
+  box-shadow: var(--shadow-sm);
+}
+
+.skeleton-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.6), transparent);
+  transform: translateX(-100%);
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
+.skeleton-line {
+  height: 0.75rem;
+  background: var(--gray-200);
+  border-radius: 999px;
+  margin-bottom: 0.75rem;
+}
+
+.skeleton-line:last-child {
+  margin-bottom: 0;
+}
+
+.skeleton-line-lg {
+  width: 80%;
+}
+
+.skeleton-line-md {
+  width: 60%;
+}
+
+.skeleton-line-sm {
+  width: 35%;
+}
+
+.skeleton-line-offset {
+  margin-top: 1.5rem;
+}
+
+@keyframes skeleton-shimmer {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
 .cycle-summary-card {
   background: white;
   border: 1px solid var(--gray-200);
@@ -4556,6 +4618,20 @@ select.input {
   background: rgba(30, 41, 59, 0.92);
   border-color: rgba(148, 163, 184, 0.1);
   box-shadow: none;
+}
+
+[data-theme="dark"] .skeleton-card {
+  background: rgba(30, 41, 59, 0.92);
+  border-color: rgba(148, 163, 184, 0.1);
+  box-shadow: none;
+}
+
+[data-theme="dark"] .skeleton-card::after {
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.12), transparent);
+}
+
+[data-theme="dark"] .skeleton-line {
+  background: rgba(148, 163, 184, 0.2);
 }
 
 [data-theme="dark"] .category-list li {


### PR DESCRIPTION
## Summary
- cache budgets and categories in localStorage to hydrate the UI instantly and throttle refreshes
- render a budgets skeleton while new data loads and streamline settings by removing the clear cache action
- narrow Supabase selects and restore auth sessions directly from the stored client session

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d826a82a6c832e81a5322162a6b49e