### PR TITLE
Trigger Supabase refresh after stale budget mutations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -147,6 +147,7 @@ function AppContent() {
   const [viewMode, setViewMode] = useState("budgets")
   const [dataPhase, setDataPhase] = useState("idle")
   const [cacheStatus, setCacheStatus] = useState({ budgets: false, categories: false })
+  const [refreshToken, setRefreshToken] = useState(0)
   const lastFetchedUserIdRef = useRef(null)
   const cacheStatusRef = useRef(cacheStatus)
   const refreshTimerRef = useRef(null)
@@ -176,6 +177,7 @@ function AppContent() {
         }
         return latestHasCache ? "refreshing" : "loading"
       })
+      setRefreshToken((token) => token + 1)
     }, delay)
   }, [user?.id])
 
@@ -451,7 +453,7 @@ function AppContent() {
     return () => {
       isCurrent = false
     }
-  }, [user, authLoading, initializing, setBudgets, hasCachedData])
+  }, [user, authLoading, initializing, setBudgets, hasCachedData, refreshToken])
 
   const updateCategories = async (nextCategories) => {
     const validatedCategories = sanitizeCategories(nextCategories)


### PR DESCRIPTION
## Summary
- add a refresh token state that forces the data-loading effect to refetch when data is marked stale
- bump the refresh token when the stale timer fires so Supabase budgets/categories are reloaded

## Testing
- npm run build *(fails: missing optional rollup native dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d82e588638832ebee01b2246363138