### PR TITLE
Handle preference update failures optimistically

### DIFF
--- a/scripts/simulatePreferencesFailure.js
+++ b/scripts/simulatePreferencesFailure.js
@@ -1,0 +1,53 @@
+import { persistPreferencesUpdate } from "../src/screens/preferencesPersistence.js"
+
+const initialPreferences = {
+  budgetStyle: "zero-based",
+  currency: "USD",
+  notifications: {
+    weeklyReports: true,
+    aiNudges: true,
+  },
+}
+
+const state = { current: initialPreferences }
+const logs = []
+
+const pendingRef = { current: null }
+
+const result = await persistPreferencesUpdate({
+  userId: "user-123",
+  updater: (current) => ({
+    ...current,
+    currency: "EUR",
+    notifications: {
+      ...current.notifications,
+      weeklyReports: false,
+    },
+  }),
+  getCurrentPreferences: () => state.current,
+  setPreferencesState: (next) => {
+    logs.push({ type: "state", next })
+    state.current = next
+  },
+  setPreferencesStatus: (status) => logs.push({ type: "status", status }),
+  setPreferencesError: (error) => logs.push({ type: "error", error }),
+  setUtilityStatus: () => logs.push({ type: "utility", cleared: true }),
+  updateUserProfileFn: async () => {
+    throw new Error("Simulated failure")
+  },
+  setUserProfile: () => logs.push({ type: "profile" }),
+  refreshProfile: async () => logs.push({ type: "refresh" }),
+  pendingRef,
+})
+
+console.log(
+  JSON.stringify(
+    {
+      result,
+      finalState: state.current,
+      logs,
+    },
+    null,
+    2,
+  ),
+)

--- a/src/screens/SettingsScreen.jsx
+++ b/src/screens/SettingsScreen.jsx
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import PropTypes from "prop-types"
 import { signOut, updateUserProfile } from "../lib/supabase"
 import { useAuth } from "../contexts/AuthContext"
+import { persistPreferencesUpdate } from "./preferencesPersistence"
 
 const THEME_STORAGE_KEY = "pb:theme-preference"
 
@@ -105,6 +106,7 @@ export default function SettingsScreen({ user, categories, budgets, onManageCate
   const [preferencesStatus, setPreferencesStatus] = useState(null)
   const [preferencesError, setPreferencesError] = useState(null)
   const [utilityStatus, setUtilityStatus] = useState(null)
+  const pendingPreferencesRef = useRef(null)
   const { preference, effectiveTheme, setThemePreference, resetToSystem } = useThemePreference()
 
   useEffect(() => {
@@ -133,30 +135,19 @@ export default function SettingsScreen({ user, categories, budgets, onManageCate
   const preferencesDirty = useMemo(() => preferencesStatus === "saving", [preferencesStatus])
 
   const updatePreferences = async (updater) => {
-    if (!user?.id) return
-    setPreferencesStatus("saving")
-    setPreferencesError(null)
-    setUtilityStatus(null)
-    const nextPreferences = typeof updater === "function" ? updater(preferencesState) : updater
-    setPreferencesState(nextPreferences)
-    try {
-      const { data, error } = await updateUserProfile(user.id, { preferences: nextPreferences })
-      if (error) {
-        setPreferencesError(error.message || "Unable to save preferences")
-        setPreferencesStatus("error")
-        return
-      }
-      if (data) {
-        setUserProfile?.(data)
-      } else {
-        await refreshProfile?.()
-      }
-      setPreferencesStatus("saved")
-    } catch (error) {
-      console.error("Failed to update preferences", error)
-      setPreferencesError(error.message || "Unexpected error saving preferences")
-      setPreferencesStatus("error")
-    }
+    await persistPreferencesUpdate({
+      userId: user?.id,
+      updater,
+      getCurrentPreferences: () => preferencesState,
+      setPreferencesState,
+      setPreferencesStatus,
+      setPreferencesError,
+      setUtilityStatus,
+      updateUserProfileFn: updateUserProfile,
+      setUserProfile,
+      refreshProfile,
+      pendingRef: pendingPreferencesRef,
+    })
   }
 
   const handleProfileSubmit = async (event) => {

--- a/src/screens/preferencesPersistence.js
+++ b/src/screens/preferencesPersistence.js
@@ -1,0 +1,84 @@
+export const clonePreferencesState = (preferences) => {
+  if (!preferences) return {}
+  try {
+    return JSON.parse(JSON.stringify(preferences))
+  } catch (error) {
+    console.warn("Failed to clone preferences state", error)
+    return preferences
+  }
+}
+
+const revertPreferencesState = (pendingRef, requestToken, setPreferencesState) => {
+  if (!pendingRef?.current || pendingRef.current.token !== requestToken) return
+  const { previous } = pendingRef.current
+  pendingRef.current = null
+  setPreferencesState(previous)
+}
+
+export const persistPreferencesUpdate = async ({
+  userId,
+  updater,
+  getCurrentPreferences,
+  setPreferencesState,
+  setPreferencesStatus,
+  setPreferencesError,
+  setUtilityStatus,
+  updateUserProfileFn,
+  setUserProfile,
+  refreshProfile,
+  pendingRef,
+}) => {
+  if (!userId) {
+    return { success: false, reason: "missing-user" }
+  }
+
+  setPreferencesStatus?.("saving")
+  setPreferencesError?.(null)
+  setUtilityStatus?.(null)
+
+  const currentPreferences = getCurrentPreferences?.() ?? {}
+  const previousPreferences = clonePreferencesState(currentPreferences)
+  const baseForUpdate = clonePreferencesState(previousPreferences)
+  const nextPreferences =
+    typeof updater === "function" ? updater(baseForUpdate) : updater
+
+  const requestToken = Symbol("preferences-update")
+  if (pendingRef) {
+    pendingRef.current = { token: requestToken, previous: previousPreferences }
+  }
+
+  setPreferencesState(nextPreferences)
+
+  try {
+    const { data, error } = await updateUserProfileFn(userId, {
+      preferences: nextPreferences,
+    })
+    if (error) {
+      const message = error.message || "Unable to save preferences"
+      setPreferencesError?.(message)
+      setPreferencesStatus?.("error")
+      revertPreferencesState(pendingRef, requestToken, setPreferencesState)
+      return { success: false, reason: "api-error", message }
+    }
+
+    if (data) {
+      setUserProfile?.(data)
+    } else {
+      await refreshProfile?.()
+    }
+
+    if (pendingRef?.current && pendingRef.current.token === requestToken) {
+      pendingRef.current = null
+    }
+
+    setPreferencesStatus?.("saved")
+    return { success: true }
+  } catch (error) {
+    const message = error.message || "Unexpected error saving preferences"
+    console.error("Failed to update preferences", error)
+    setPreferencesError?.(message)
+    setPreferencesStatus?.("error")
+    revertPreferencesState(pendingRef, requestToken, setPreferencesState)
+    return { success: false, reason: "exception", message }
+  }
+}


### PR DESCRIPTION
## Summary
- ensure settings screen preference updates capture the previous state before persisting
- extract a reusable helper to revert UI changes when an API call fails
- add a manual simulation script to verify the rollback behavior on rejected updates

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*
- node scripts/simulatePreferencesFailure.js


------
https://chatgpt.com/codex/tasks/task_e_68d82e573a88832e9a135db56fe7ee03